### PR TITLE
Avoid string concatenation in PHPMethod

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ jobs:
       install: "skip"
       script:
         - find -L . -path ./vendor -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 -- php -l
-        - tools/php-cs-fixer fix --dry-run
+        - tools/php-cs-fixer fix --dry-run --diff
     - name: "Static analysis"
       php: 7.4
       install:

--- a/src/voku/SimplePhpParser/Model/PHPFunction.php
+++ b/src/voku/SimplePhpParser/Model/PHPFunction.php
@@ -261,7 +261,7 @@ class PHPFunction extends BasePHPElement
 
                 $type = $parsedReturnTagReturn->getType();
 
-                $this->returnTypeFromPhpDoc = Utils::normalizePhpType(\ltrim($type, '\\'));
+                $this->returnTypeFromPhpDoc = Utils::normalizePhpType(\ltrim((string)$type, '\\'));
 
                 $typeTmp = Utils::parseDocTypeObject($type);
                 if ($typeTmp !== '') {
@@ -278,7 +278,7 @@ class PHPFunction extends BasePHPElement
                                + $phpDoc->getTagsByName('phpstan-return');
 
             if (!empty($parsedReturnTag) && $parsedReturnTag[0] instanceof Generic) {
-                $parsedReturnTagReturn = $parsedReturnTag[0];
+                $parsedReturnTagReturn = (string)$parsedReturnTag[0];
 
                 $this->returnTypeFromPhpDocPslam = Utils::modernPhpdoc($parsedReturnTagReturn);
             }

--- a/src/voku/SimplePhpParser/Model/PHPFunction.php
+++ b/src/voku/SimplePhpParser/Model/PHPFunction.php
@@ -96,7 +96,12 @@ class PHPFunction extends BasePHPElement
                 $this->summary = $phpDoc->getSummary();
                 $this->description = (string) $phpDoc->getDescription();
             } catch (\Exception $e) {
-                $tmpErrorMessage = $this->name . ':' . ($this->line ?? '?') . ' | ' . \print_r($e->getMessage(), true);
+                $tmpErrorMessage = sprintf(
+                    '%s:%s | %s',
+                    $this->name,
+                    $this->line ?? '?',
+                    \print_r($e->getMessage(), true)
+                );
                 $this->parseError[\md5($tmpErrorMessage)] = $tmpErrorMessage;
             }
         }
@@ -104,7 +109,11 @@ class PHPFunction extends BasePHPElement
         foreach ($node->getParams() as $parameter) {
             $parameterVar = $parameter->var;
             if ($parameterVar instanceof \PhpParser\Node\Expr\Error) {
-                $this->parseError[] = ($this->line ?? '?') . ':' . ($this->pos ?? '') . ' | may be at this position an expression is required';
+                $this->parseError[] = sprintf(
+                    '%s:%s | maybe at this position an expression is required',
+                    $this->line ?? '?',
+                    $this->pos ?? ''
+                );
 
                 return $this;
             }
@@ -252,7 +261,7 @@ class PHPFunction extends BasePHPElement
 
                 $type = $parsedReturnTagReturn->getType();
 
-                $this->returnTypeFromPhpDoc = Utils::normalizePhpType(\ltrim($type . '', '\\'));
+                $this->returnTypeFromPhpDoc = Utils::normalizePhpType(\ltrim($type, '\\'));
 
                 $typeTmp = Utils::parseDocTypeObject($type);
                 if ($typeTmp !== '') {
@@ -269,12 +278,17 @@ class PHPFunction extends BasePHPElement
                                + $phpDoc->getTagsByName('phpstan-return');
 
             if (!empty($parsedReturnTag) && $parsedReturnTag[0] instanceof Generic) {
-                $parsedReturnTagReturn = $parsedReturnTag[0] . '';
+                $parsedReturnTagReturn = $parsedReturnTag[0];
 
                 $this->returnTypeFromPhpDocPslam = Utils::modernPhpdoc($parsedReturnTagReturn);
             }
         } catch (\Exception $e) {
-            $tmpErrorMessage = $this->name . ':' . ($this->line ?? '?') . ' | ' . \print_r($e->getMessage(), true);
+            $tmpErrorMessage = sprintf(
+                '%s:%s | %s',
+                $this->name,
+                $this->line ?? '?',
+                \print_r($e->getMessage(), true)
+            );
             $this->parseError[\md5($tmpErrorMessage)] = $tmpErrorMessage;
         }
     }

--- a/src/voku/SimplePhpParser/Model/PHPFunction.php
+++ b/src/voku/SimplePhpParser/Model/PHPFunction.php
@@ -96,7 +96,7 @@ class PHPFunction extends BasePHPElement
                 $this->summary = $phpDoc->getSummary();
                 $this->description = (string) $phpDoc->getDescription();
             } catch (\Exception $e) {
-                $tmpErrorMessage = sprintf(
+                $tmpErrorMessage = \sprintf(
                     '%s:%s | %s',
                     $this->name,
                     $this->line ?? '?',
@@ -109,7 +109,7 @@ class PHPFunction extends BasePHPElement
         foreach ($node->getParams() as $parameter) {
             $parameterVar = $parameter->var;
             if ($parameterVar instanceof \PhpParser\Node\Expr\Error) {
-                $this->parseError[] = sprintf(
+                $this->parseError[] = \sprintf(
                     '%s:%s | maybe at this position an expression is required',
                     $this->line ?? '?',
                     $this->pos ?? ''
@@ -261,7 +261,7 @@ class PHPFunction extends BasePHPElement
 
                 $type = $parsedReturnTagReturn->getType();
 
-                $this->returnTypeFromPhpDoc = Utils::normalizePhpType(\ltrim((string)$type, '\\'));
+                $this->returnTypeFromPhpDoc = Utils::normalizePhpType(\ltrim((string) $type, '\\'));
 
                 $typeTmp = Utils::parseDocTypeObject($type);
                 if ($typeTmp !== '') {
@@ -278,12 +278,12 @@ class PHPFunction extends BasePHPElement
                                + $phpDoc->getTagsByName('phpstan-return');
 
             if (!empty($parsedReturnTag) && $parsedReturnTag[0] instanceof Generic) {
-                $parsedReturnTagReturn = (string)$parsedReturnTag[0];
+                $parsedReturnTagReturn = (string) $parsedReturnTag[0];
 
                 $this->returnTypeFromPhpDocPslam = Utils::modernPhpdoc($parsedReturnTagReturn);
             }
         } catch (\Exception $e) {
-            $tmpErrorMessage = sprintf(
+            $tmpErrorMessage = \sprintf(
                 '%s:%s | %s',
                 $this->name,
                 $this->line ?? '?',

--- a/src/voku/SimplePhpParser/Model/PHPMethod.php
+++ b/src/voku/SimplePhpParser/Model/PHPMethod.php
@@ -60,7 +60,13 @@ class PHPMethod extends PHPFunction
                 $this->summary = $phpDoc->getSummary();
                 $this->description = (string) $phpDoc->getDescription();
             } catch (\Exception $e) {
-                $tmpErrorMessage = $this->parentName . '->' . $this->name . ':' . ($this->line ?? '?') . ' | ' . \print_r($e->getMessage(), true);
+                $tmpErrorMessage = sprintf(
+                    '%s->%s:%s | %s',
+                    $this->parentName,
+                    $this->name,
+                    $this->line ?? '?',
+                    \print_r($e->getMessage(), true)
+                );
                 $this->parseError[\md5($tmpErrorMessage)] = $tmpErrorMessage;
             }
         }
@@ -114,7 +120,11 @@ class PHPMethod extends PHPFunction
         foreach ($node->getParams() as $parameter) {
             $parameterVar = $parameter->var;
             if ($parameterVar instanceof \PhpParser\Node\Expr\Error) {
-                $this->parseError[] = ($this->line ?? '?') . ':' . ($this->pos ?? '') . ' | may be at this position an expression is required';
+                $this->parseError[] = sprintf(
+                    '%s:%s | maybe at this position an expression is required',
+                    $this->line ?? '?',
+                    $this->pos ?? ''
+                );
 
                 return $this;
             }

--- a/src/voku/SimplePhpParser/Model/PHPMethod.php
+++ b/src/voku/SimplePhpParser/Model/PHPMethod.php
@@ -60,7 +60,7 @@ class PHPMethod extends PHPFunction
                 $this->summary = $phpDoc->getSummary();
                 $this->description = (string) $phpDoc->getDescription();
             } catch (\Exception $e) {
-                $tmpErrorMessage = sprintf(
+                $tmpErrorMessage = \sprintf(
                     '%s->%s:%s | %s',
                     $this->parentName,
                     $this->name,
@@ -120,7 +120,7 @@ class PHPMethod extends PHPFunction
         foreach ($node->getParams() as $parameter) {
             $parameterVar = $parameter->var;
             if ($parameterVar instanceof \PhpParser\Node\Expr\Error) {
-                $this->parseError[] = sprintf(
+                $this->parseError[] = \sprintf(
                     '%s:%s | maybe at this position an expression is required',
                     $this->line ?? '?',
                     $this->pos ?? ''


### PR DESCRIPTION
An army 💂💂💂 of `.`-s may defeat us.