### PR TITLE
Change `final class` to `class`

### DIFF
--- a/src/voku/SimplePhpParser/Model/PHPTrait.php
+++ b/src/voku/SimplePhpParser/Model/PHPTrait.php
@@ -9,7 +9,7 @@ use PhpParser\Node\Stmt\Trait_;
 use ReflectionClass;
 use voku\SimplePhpParser\Parsers\Helper\Utils;
 
-final class PHPTrait extends BasePHPClass
+class PHPTrait extends BasePHPClass
 {
     /**
      * @phpstan-var class-string

--- a/src/voku/SimplePhpParser/Parsers/Helper/DocFactoryProvider.php
+++ b/src/voku/SimplePhpParser/Parsers/Helper/DocFactoryProvider.php
@@ -6,7 +6,7 @@ namespace voku\SimplePhpParser\Parsers\Helper;
 
 use phpDocumentor\Reflection\DocBlockFactory;
 
-final class DocFactoryProvider
+class DocFactoryProvider
 {
     private static ?DocBlockFactory $docFactory = null;
 

--- a/src/voku/SimplePhpParser/Parsers/Helper/ParserErrorHandler.php
+++ b/src/voku/SimplePhpParser/Parsers/Helper/ParserErrorHandler.php
@@ -7,7 +7,7 @@ namespace voku\SimplePhpParser\Parsers\Helper;
 use PhpParser\Error;
 use PhpParser\ErrorHandler;
 
-final class ParserErrorHandler extends ErrorHandler\Collecting
+class ParserErrorHandler extends ErrorHandler\Collecting
 {
     /**
      * Handle an error generated during lexing, parsing or some other operation.

--- a/src/voku/SimplePhpParser/Parsers/Helper/Utils.php
+++ b/src/voku/SimplePhpParser/Parsers/Helper/Utils.php
@@ -10,7 +10,7 @@ use RecursiveIteratorIterator;
 use ReflectionClass;
 use ReflectionFunction;
 
-final class Utils
+class Utils
 {
     public const GET_PHP_PARSER_VALUE_FROM_NODE_HELPER = '!!!_SIMPLE_PHP_CODE_PARSER_HELPER_!!!';
 

--- a/src/voku/SimplePhpParser/Parsers/PhpCodeParser.php
+++ b/src/voku/SimplePhpParser/Parsers/PhpCodeParser.php
@@ -23,7 +23,7 @@ use voku\SimplePhpParser\Parsers\Visitors\ParentConnector;
 use function React\Async\await;
 use function React\Promise\all;
 
-final class PhpCodeParser
+class PhpCodeParser
 {
     /**
      * @internal

--- a/src/voku/SimplePhpParser/Parsers/Visitors/ASTVisitor.php
+++ b/src/voku/SimplePhpParser/Parsers/Visitors/ASTVisitor.php
@@ -21,7 +21,7 @@ use voku\SimplePhpParser\Model\PHPTrait;
 use voku\SimplePhpParser\Parsers\Helper\ParserContainer;
 use voku\SimplePhpParser\Parsers\Helper\Utils;
 
-final class ASTVisitor extends NodeVisitorAbstract
+class ASTVisitor extends NodeVisitorAbstract
 {
     /**
      * @var string|null

--- a/src/voku/SimplePhpParser/Parsers/Visitors/ParentConnector.php
+++ b/src/voku/SimplePhpParser/Parsers/Visitors/ParentConnector.php
@@ -10,7 +10,7 @@ use PhpParser\NodeVisitorAbstract;
 /**
  * The visitor is required to provide "parent" attribute to nodes
  */
-final class ParentConnector extends NodeVisitorAbstract
+class ParentConnector extends NodeVisitorAbstract
 {
     /**
      * @var Node[]


### PR DESCRIPTION
I'm using `php-parser` >5 in my project, [BrianHenryIE/strauss](https://github.com/BrianHenryIE/strauss/).

This package looks like it addresses a lot of the work I was about to undertake, thank you.

Unfortunately, due to version differences, I get:

```
Error : Call to undefined method PhpParser\ParserFactory::create()
 /path/to/vendor/voku/simple-php-code-parser/src/voku/SimplePhpParser/Parsers/PhpCodeParser.php:203
```

https://github.com/voku/Simple-PHP-Code-Parser/blob/b72daffe2d9b4766f548331c0a00835242cd4dea/src/voku/SimplePhpParser/Parsers/PhpCodeParser.php#L203

If I were able to extend the `PhpCodeParser` class I could maybe address this without forking or relying on a merged PR, but it is a `final` class:

https://github.com/voku/Simple-PHP-Code-Parser/blob/b72daffe2d9b4766f548331c0a00835242cd4dea/src/voku/SimplePhpParser/Parsers/PhpCodeParser.php#L26

#### Proposed Changes

Remove `final` from all classes.
