### PR TITLE
Upgrade `nikic/php-parser` to v5+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ composer.lock
 # php (phpunit)
 build/logs/
 .phpunit.result.cache
+/.phpunit.result/
 
 # phpcs fixer
 .php_cs.cache

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "phpdocumentor/reflection-common": "~2.2",
         "phpstan/phpdoc-parser": "~1.23",
         "voku/simple-cache": "~4.1",
-        "nikic/php-parser": "~4.16"
+        "nikic/php-parser": "^5"
     },
     "require-dev": {
         "phpunit/phpunit": "~6.0 || ~7.0 || ~9.0"

--- a/composer.json
+++ b/composer.json
@@ -38,5 +38,16 @@
         "psr-4": {
             "voku\\tests\\": "tests/"
         }
+    },
+    "scripts": {
+        "test-coverage": [
+            "Composer\\Config::disableProcessTimeout",
+            "if [ \"$XDEBUG_MODE\" != \"coverage\" ]; then echo \"Run with 'XDEBUG_MODE=coverage composer test-coverage'\"; exit 1; fi;",
+            "phpunit --coverage-text --coverage-clover .phpunit.result/unitclover.xml --coverage-php .phpunit.result/unitphp.cov --coverage-html .phpunit.result/html -d memory_limit=-1 --order-by=random",
+            "# Run 'open ./.phpunit.result/html/index.html' to view report."
+        ]
+    },
+    "scripts-descriptions": {
+        "test-coverage": "Run PHPUnit tests with coverage. Use 'XDEBUG_MODE=coverage composer test-coverage' to run, 'open ./.phpunit.result/html/index.html' to view."
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "phpdocumentor/reflection-common": "~2.2",
         "phpstan/phpdoc-parser": "~1.23",
         "voku/simple-cache": "~4.1",
-        "nikic/php-parser": "^5"
+        "nikic/php-parser": "^4.18 || ^5"
     },
     "require-dev": {
         "phpunit/phpunit": "~6.0 || ~7.0 || ~9.0"

--- a/src/voku/SimplePhpParser/Model/BasePHPElement.php
+++ b/src/voku/SimplePhpParser/Model/BasePHPElement.php
@@ -97,6 +97,13 @@ abstract class BasePHPElement
 
     protected function prepareNode(Node $node): void
     {
-        $this->line = $node->getLine();
+        $this->line = method_exists($node, 'getStartLine')
+            ? $node->getStartLine()
+            /**
+             * Deprecated in PHP-Parser v5
+             *
+             * @see https://github.com/nikic/PHP-Parser/blob/master/UPGRADE-5.0.md#miscellaneous-changes
+             */
+            : $node->getLine();
     }
 }

--- a/src/voku/SimplePhpParser/Parsers/Helper/Utils.php
+++ b/src/voku/SimplePhpParser/Parsers/Helper/Utils.php
@@ -112,7 +112,9 @@ final class Utils
                     &&
                     $node->value->name
                 ) {
-                    $value = implode('\\', $node->value->name->getParts()) ?: $node->value->name->name;
+                    $value = method_exists($node->value->name,'getParts')
+                        ? implode('\\', $node->value->name->getParts())
+                        : $node->value->name->name;
                     return $value === 'null' ? null : $value;
                 }
             }

--- a/src/voku/SimplePhpParser/Parsers/Helper/Utils.php
+++ b/src/voku/SimplePhpParser/Parsers/Helper/Utils.php
@@ -495,6 +495,23 @@ final class Utils
             }
         }
 
+        /**
+         * macOS (FreeBSD)
+         */
+        $ret = @\shell_exec('sysctl -n hw.ncpu');
+        if (\is_string($ret)) {
+            $ret = \trim($ret);
+            /** @noinspection PhpAssignmentInConditionInspection */
+            if ($ret && ($tmp = \filter_var($ret, \FILTER_VALIDATE_INT)) !== false) {
+                $return = (int)round($tmp / 2);
+                if ($return > 1) {
+                    return $return;
+                }
+
+                return 1;
+            }
+        }
+
         return 1;
     }
 

--- a/src/voku/SimplePhpParser/Parsers/Helper/Utils.php
+++ b/src/voku/SimplePhpParser/Parsers/Helper/Utils.php
@@ -468,7 +468,7 @@ final class Utils
         }
 
         /** @noinspection PhpUsageOfSilenceOperatorInspection */
-        $ret = @\shell_exec('nproc');
+        $ret = @\shell_exec('nproc 2>&1');
         if (\is_string($ret)) {
             $ret = \trim($ret);
             /** @noinspection PhpAssignmentInConditionInspection */

--- a/src/voku/SimplePhpParser/Parsers/PhpCodeParser.php
+++ b/src/voku/SimplePhpParser/Parsers/PhpCodeParser.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace voku\SimplePhpParser\Parsers;
 
 use FilesystemIterator;
-use PhpParser\Lexer\Emulative;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\NameResolver;
 use PhpParser\ParserFactory;
@@ -200,20 +199,7 @@ final class PhpCodeParser
         ParserContainer $parserContainer,
         ASTVisitor $visitor
     ) {
-        $parser = (new ParserFactory())->create(
-            ParserFactory::PREFER_PHP7,
-            new Emulative(
-                [
-                    'usedAttributes' => [
-                        'comments',
-                        'startLine',
-                        'endLine',
-                        'startTokenPos',
-                        'endTokenPos',
-                    ],
-                ]
-            )
-        );
+        $parser = (new ParserFactory())->createForNewestSupportedVersion();
 
         $errorHandler = new ParserErrorHandler();
 


### PR DESCRIPTION
PR is to upgrade to [`php-parser`](https://github.com/nikic/PHP-Parser/)  5.x.

I made some DX changes on my way to updating `php-parser` library, I will cherry-pick these commits as independent PRs if you prefer. 

#### Tangential commits:

* [Mute command not found: `nproc`](https://github.com/voku/Simple-PHP-Code-Parser/commit/2392fd81c8d35c2e1d50eb26dd9cd3baa85fa2fa) – When running tests on MacOS, the stderr output was always printed, so I redirect it to stdio which is then parsed as normal
* [Determine number of cores on macOS](https://github.com/voku/Simple-PHP-Code-Parser/commit/5836d87e7879734ad694ed6abb18fdc0c9ea5ada) – intention is to add the corresponding function for the missing `nproc`
* [Add `test-coverage` Composer script](https://github.com/voku/Simple-PHP-Code-Parser/commit/6f1542fb2b3454e2094d881fb9bab486d8522ced) – I wanted an easy way to see the current coverage HTML report so I might identify anywhere that my changes need new tests. Current coverage is 80%.
#### Proposed Changes

These are the guts of the PR, and much less work than I expected: [c55dc7a...a436917](https://github.com/BrianHenryIE/Simple-PHP-Code-Parser/compare/c55dc7aad778426776a25df76c6fa806bd4a5784...a436917e6b1a86850fe070b1e923e7b0d7508afc)

`php-parser` has a [UPGRADE-5.0](https://github.com/nikic/PHP-Parser/blob/master/UPGRADE-5.0.md) guide. I've added checkboxes for each heading it has to try make reviewing as easy as possible:

* [ ] [PHP version requirements](https://github.com/nikic/PHP-Parser/blob/master/UPGRADE-5.0.md#php-version-requirements) – seems irrelevant since this library already has [a PHP 7.4 minimum](https://github.com/voku/Simple-PHP-Code-Parser/blob/b72daffe2d9b4766f548331c0a00835242cd4dea/composer.json#L19)
* [ ] [PHP 5 parsing support](https://github.com/nikic/PHP-Parser/blob/master/UPGRADE-5.0.md#php-5-parsing-support) – as above, NA?
* [ ] [Changes to the parser factory](https://github.com/nikic/PHP-Parser/blob/master/UPGRADE-5.0.md#changes-to-the-parser-factory)

<img width="513" alt="Screenshot 2025-05-31 at 7 35 46 PM" src="https://github.com/user-attachments/assets/7f37c9da-385e-42d4-8a9a-828c1f8cf31a" />

[c55dc7a Instantiate parser via `::createForNewestSupportedVersion()`](https://github.com/voku/Simple-PHP-Code-Parser/commit/c55dc7aad778426776a25df76c6fa806bd4a5784)

> The createForNewestSupportedVersion() and creatForHostVersion() are available since PHP-Parser 4.18.0, to allow libraries to support PHP-Parser 4 and 5 at the same time more easily.

`composer require "nikic/php-parser":"^4.18 || ^5"` (in https://github.com/BrianHenryIE/Simple-PHP-Code-Parser/commit/846e011e7382b12fdab723ebebaffc778962205f, https://github.com/BrianHenryIE/Simple-PHP-Code-Parser/commit/63113e2b5e8f599889793546dfa70e010c1b8351)

* [ ] [Changes to the throw representation](https://github.com/nikic/PHP-Parser/blob/master/UPGRADE-5.0.md#changes-to-the-throw-representation) – I searched for exception handling in this library and there is only `Exception` and `ReflectionException`, so I don't think there's any changes here
* [ ] [Changes to the array destructuring representation](https://github.com/nikic/PHP-Parser/blob/master/UPGRADE-5.0.md#changes-to-the-array-destructuring-representation)
* [ ] [Changes to the name representation](https://github.com/nikic/PHP-Parser/blob/master/UPGRADE-5.0.md#changes-to-the-name-representation) – [9356c18 Check `method_exists` for deprecated `::getParts()`](https://github.com/voku/Simple-PHP-Code-Parser/commit/9356c18a1e551851fafa0324410d4d38dc813337)
* [ ] [Changes to the block representation](https://github.com/nikic/PHP-Parser/blob/master/UPGRADE-5.0.md#changes-to-the-block-representation)
* [ ] [Changes to comment assignment](https://github.com/nikic/PHP-Parser/blob/master/UPGRADE-5.0.md#changes-to-comment-assignment)
* [ ] [Renamed nodes](https://github.com/nikic/PHP-Parser/blob/master/UPGRADE-5.0.md#changes-to-comment-assignment) – I searched for `Scalar` and didn't find anything relevant
* [ ] [Modifiers](https://github.com/nikic/PHP-Parser/blob/master/UPGRADE-5.0.md#modifiers) – `modifier/i` is not used in this project's code
* [ ] [Changes to node constructors](https://github.com/nikic/PHP-Parser/blob/master/UPGRADE-5.0.md#changes-to-node-constructors)
* [ ] [Changes to the pretty printer](https://github.com/nikic/PHP-Parser/blob/master/UPGRADE-5.0.md#changes-to-the-pretty-printer) – no uses
* [ ] [Changes to precedence handling in the pretty printer](https://github.com/nikic/PHP-Parser/blob/master/UPGRADE-5.0.md#changes-to-precedence-handling-in-the-pretty-printer) – NA
* [ ] [Changes to token representation](https://github.com/nikic/PHP-Parser/blob/master/UPGRADE-5.0.md#changes-to-token-representation) – I don't see any use of the fields in the described interface
* [ ] [Changes to the lexer](https://github.com/nikic/PHP-Parser/blob/master/UPGRADE-5.0.md#changes-to-the-lexer) – Lexer does not appear to be used directly
* [ ] [Miscellaneous changes](https://github.com/nikic/PHP-Parser/blob/master/UPGRADE-5.0.md#miscellaneous-changes) – mostly clear; `Node::getLine()` addressed in a436917e6b1a86850fe070b1e923e7b0d7508afc

I don't _think_ this is a breaking change, but I haven't used this widely enough to be sure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `test-coverage` composer command for generating code coverage reports in multiple formats including HTML output.

* **Bug Fixes**
  * Enhanced CPU core detection on non-Windows systems with additional fallback mechanisms.

* **Documentation**
  * Added deprecation annotations for improved code clarity.

* **Chores**
  * Updated project ignore patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->