### PR TITLE
dogfood: replay real issue #60 through isolated agent-loop tooling

### DIFF
--- a/.github/workflows/agent-loop-real-issue-dogfood.yml
+++ b/.github/workflows/agent-loop-real-issue-dogfood.yml
@@ -1,0 +1,214 @@
+name: Agent Loop Real Issue Dogfood
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - dogfood/issue-60-agent-loop
+  pull_request:
+    paths:
+      - '.github/workflows/agent-loop-real-issue-dogfood.yml'
+      - 'tools/agent-loop/**'
+
+permissions:
+  contents: read
+
+jobs:
+  replay-issue-60:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout dogfood harness
+        uses: actions/checkout@v4
+        with:
+          path: harness
+          persist-credentials: false
+
+      - name: Checkout frozen pre-fix target
+        uses: actions/checkout@v4
+        with:
+          repository: voku/Simple-PHP-Code-Parser
+          ref: 5156d5d74ca1bce275219f4571efd54ec44be911
+          path: target
+          persist-credentials: false
+
+      - name: Checkout Recall candidate discovered by the replay
+        uses: actions/checkout@v4
+        with:
+          repository: voku/agent-recall-compiler
+          ref: 5a2710970e68e41c96a7c5d015f573fd4ec1d289
+          path: candidate/agent-recall-compiler
+          persist-credentials: false
+
+      - name: Checkout pinned L2 skill catalog
+        uses: actions/checkout@v4
+        with:
+          repository: voku/agent-skills
+          ref: c7e9d8bdda59d957600bca8dc9f787f03286b277
+          path: skills
+          persist-credentials: false
+
+      - name: Setup PHP and Composer
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: json, mbstring, pdo_sqlite, sqlite3
+          coverage: none
+          tools: composer:v2
+
+      - name: Validate frozen input and target
+        run: |
+          set -euo pipefail
+          expected="$(jq -r '.target_base_commit' harness/tools/agent-loop/dogfood/issue-60.json)"
+          actual="$(git -C target rev-parse HEAD)"
+          test "${actual}" = "${expected}"
+          test "$(jq -r '.toolchain.agent_skills_commit' harness/tools/agent-loop/dogfood/issue-60.json)" = "$(git -C skills rev-parse HEAD)"
+          test "$(jq -r '.toolchain.agent_recall_compiler_candidate_commit' harness/tools/agent-loop/dogfood/issue-60.json)" = "$(git -C candidate/agent-recall-compiler rev-parse HEAD)"
+
+      - name: Inject only the Recall candidate into the isolated tool project
+        run: |
+          set -euo pipefail
+          php -r '
+          $path = "harness/tools/agent-loop/composer.json";
+          $data = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+          array_unshift($data["repositories"], [
+              "type" => "path",
+              "url" => "../../../candidate/agent-recall-compiler",
+              "options" => [
+                  "symlink" => false,
+                  "versions" => ["voku/agent-recall-compiler" => "0.10.99"],
+              ],
+          ]);
+          $data["require-dev"]["voku/agent-recall-compiler"] = "0.10.99";
+          file_put_contents($path, json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . PHP_EOL);
+          '
+          composer update --working-dir=harness/tools/agent-loop --no-interaction --prefer-dist --no-progress
+
+      - name: Install historical target dependencies
+        run: composer install --working-dir=target --no-interaction --prefer-dist --no-progress
+
+      - name: Build frozen pre-fix map and search from issue text only
+        run: |
+          set -euo pipefail
+          out='target/.agent-loop/dogfood/issue-60'
+          mkdir -p "${out}/learning" "${out}/recall" 'target/.agent-loop/map'
+
+          harness/tools/agent-loop/vendor/bin/agent-map build \
+            --root=target \
+            --paths=src,tests \
+            --out=target/.agent-loop/map/php-symbols.json
+
+          harness/tools/agent-loop/vendor/bin/agent-map search-index build \
+            --root=target \
+            --index=target/.agent-loop/map/php-symbols.json \
+            --database=target/.agent-loop/map/search.sqlite
+
+          query="$(jq -r '.issue | .title + "\n\n" + .body' harness/tools/agent-loop/dogfood/issue-60.json)"
+          harness/tools/agent-loop/vendor/bin/agent-map search "${query}" \
+            --root=target \
+            --index=target/.agent-loop/map/php-symbols.json \
+            --database=target/.agent-loop/map/search.sqlite \
+            --limit=10 \
+            --format=json > "${out}/map-search.json"
+
+      - name: Compile project-specific Recall and L2 contract input
+        run: |
+          set -euo pipefail
+          out='target/.agent-loop/dogfood/issue-60'
+          cat > "${out}/learning/config.json" <<'JSON'
+          {
+            "schema_version": "1.0",
+            "project_root": "../../../.."
+          }
+          JSON
+
+          query="$(jq -r '.issue | .title + "\n\n" + .body' harness/tools/agent-loop/dogfood/issue-60.json)"
+          harness/tools/agent-loop/vendor/bin/agent-recall-compiler compile \
+            --root "${out}/learning" \
+            --task GH-60 \
+            --description "${query}" \
+            --map-index target/.agent-loop/map/php-symbols.json \
+            --map-root target \
+            --map-search-index target/.agent-loop/map/search.sqlite \
+            --map-search-limit 10 \
+            --operating-prompt-manifest skills/skills/operational-prompting/operating-prompts.json \
+            --operating-prompt '{"id":"reproduce-before-fix","arguments":{}}' \
+            --output-dir "${out}/recall"
+
+      - name: Enforce deterministic Recall and L2 gates
+        run: |
+          set -euo pipefail
+          facts='target/.agent-loop/dogfood/issue-60/recall/facts.json'
+          system='target/.agent-loop/dogfood/issue-60/recall/system.md'
+
+          jq -e '
+            .facts[]
+            | select(.id == "project.capabilities")
+            | .payload.mentioned_direct_dependencies["react/filesystem"]
+            | select(.section == "require" and .constraint == "^0.2@dev")
+          ' "${facts}" >/dev/null
+
+          jq -e '
+            .facts[]
+            | select(.id == "project.capabilities")
+            | .payload.composer_scripts
+            | select(type == "object" and length == 0)
+          ' "${facts}" >/dev/null
+
+          grep -F 'L2 Operational Prompt Construction' "${system}" >/dev/null
+
+      - name: Compare frozen context with the later verified fix
+        run: |
+          set -euo pipefail
+          out='target/.agent-loop/dogfood/issue-60'
+          oracle='harness/tools/agent-loop/dogfood/issue-60-oracle.json'
+          expected_file="$(jq -r '.expected_channels.agent_map[0]' "${oracle}")"
+          map_rank="$(jq --arg file "${expected_file}" '[.results[].file_path] | index($file) | if . == null then null else . + 1 end' "${out}/map-search.json")"
+          map_count="$(jq '.results | length' "${out}/map-search.json")"
+
+          jq -n \
+            --arg expected_file "${expected_file}" \
+            --argjson map_rank "${map_rank}" \
+            --argjson map_count "${map_count}" \
+            '{
+              schema_version: "1.0",
+              issue: 60,
+              hard_gates: {
+                recall_named_dependency_hit: true,
+                recall_did_not_invent_composer_scripts: true,
+                l2_construction_contract_present: true
+              },
+              observations: {
+                agent_map_expected_production_file: $expected_file,
+                agent_map_hit: ($map_rank != null),
+                agent_map_rank: $map_rank,
+                agent_map_result_count: $map_count
+              }
+            }' > "${out}/evaluation.json"
+
+          cat "${out}/evaluation.json"
+
+      - name: Capture replay provenance
+        if: always()
+        run: |
+          set -euo pipefail
+          out='target/.agent-loop/dogfood/issue-60'
+          mkdir -p "${out}"
+          cp harness/tools/agent-loop/composer.lock "${out}/tool-composer.lock" 2>/dev/null || true
+          composer show --working-dir=harness/tools/agent-loop --format=json > "${out}/tool-packages.json" 2>/dev/null || true
+          sha256sum skills/skills/operational-prompting/operating-prompts.json > "${out}/operating-prompts.sha256" 2>/dev/null || true
+          git -C target rev-parse HEAD > "${out}/target-commit.txt"
+          git -C candidate/agent-recall-compiler rev-parse HEAD > "${out}/recall-candidate-commit.txt"
+          git -C skills rev-parse HEAD > "${out}/skills-commit.txt"
+
+      - name: Upload replay evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: real-issue-60-dogfood-${{ github.sha }}
+          if-no-files-found: error
+          include-hidden-files: true
+          path: |
+            target/.agent-loop/dogfood/issue-60
+            target/.agent-loop/map/php-symbols.json

--- a/.github/workflows/agent-loop-real-issue-dogfood.yml
+++ b/.github/workflows/agent-loop-real-issue-dogfood.yml
@@ -171,10 +171,11 @@ jobs:
             .facts[]
             | select(.id == "project.capabilities")
             | .payload.composer_scripts
-            | select(type == "object" and length == 0)
+            | select(length == 0)
           ' "${facts}" >/dev/null
 
           grep -F 'L2 Operational Prompt Construction' "${system}" >/dev/null
+          grep -F 'Never invent repository commands, tools, APIs, or architectural rules.' "${system}" >/dev/null
 
       - name: Compare frozen context with the later verified fix
         run: |
@@ -195,7 +196,8 @@ jobs:
               hard_gates: {
                 recall_named_dependency_hit: true,
                 recall_did_not_invent_composer_scripts: true,
-                l2_construction_contract_present: true
+                l2_construction_contract_present: true,
+                l2_command_honesty_rule_present: true
               },
               observations: {
                 agent_map_expected_production_file: $expected_file,

--- a/.github/workflows/agent-loop-real-issue-dogfood.yml
+++ b/.github/workflows/agent-loop-real-issue-dogfood.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: voku/agent-loop
-          ref: 9db5683b79996928553e13dcdb976037615d5742
+          ref: 206cfdb3199740d85f342699e34a19744c554ef5
           path: toolchain/agent-loop
           persist-credentials: false
 
@@ -94,11 +94,11 @@ jobs:
                   "url" => "../../../candidate/agent-recall-compiler",
                   "options" => [
                       "symlink" => false,
-                      "versions" => ["voku/agent-recall-compiler" => "0.10.99"],
+                      "versions" => ["voku/agent-recall-compiler" => "0.11.99"],
                   ],
               ],
           ];
-          $data["require-dev"]["voku/agent-recall-compiler"] = "0.10.99";
+          $data["require-dev"]["voku/agent-recall-compiler"] = "0.11.99";
           file_put_contents($path, json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . PHP_EOL);
           '
           composer update --working-dir=harness/tools/agent-loop --no-interaction --prefer-dist --no-progress

--- a/.github/workflows/agent-loop-real-issue-dogfood.yml
+++ b/.github/workflows/agent-loop-real-issue-dogfood.yml
@@ -33,6 +33,14 @@ jobs:
           path: target
           persist-credentials: false
 
+      - name: Checkout pinned agent-loop source and metadata
+        uses: actions/checkout@v4
+        with:
+          repository: voku/agent-loop
+          ref: 9db5683b79996928553e13dcdb976037615d5742
+          path: toolchain/agent-loop
+          persist-credentials: false
+
       - name: Checkout Recall candidate discovered by the replay
         uses: actions/checkout@v4
         with:
@@ -60,26 +68,36 @@ jobs:
       - name: Validate frozen input and target
         run: |
           set -euo pipefail
-          expected="$(jq -r '.target_base_commit' harness/tools/agent-loop/dogfood/issue-60.json)"
-          actual="$(git -C target rev-parse HEAD)"
-          test "${actual}" = "${expected}"
-          test "$(jq -r '.toolchain.agent_skills_commit' harness/tools/agent-loop/dogfood/issue-60.json)" = "$(git -C skills rev-parse HEAD)"
-          test "$(jq -r '.toolchain.agent_recall_compiler_candidate_commit' harness/tools/agent-loop/dogfood/issue-60.json)" = "$(git -C candidate/agent-recall-compiler rev-parse HEAD)"
+          issue='harness/tools/agent-loop/dogfood/issue-60.json'
+          test "$(jq -r '.target_base_commit' "${issue}")" = "$(git -C target rev-parse HEAD)"
+          test "$(jq -r '.toolchain.agent_loop_commit' "${issue}")" = "$(git -C toolchain/agent-loop rev-parse HEAD)"
+          test "$(jq -r '.toolchain.agent_skills_commit' "${issue}")" = "$(git -C skills rev-parse HEAD)"
+          test "$(jq -r '.toolchain.agent_recall_compiler_candidate_commit' "${issue}")" = "$(git -C candidate/agent-recall-compiler rev-parse HEAD)"
 
-      - name: Inject only the Recall candidate into the isolated tool project
+      - name: Inject exact source checkouts into the isolated tool project
         run: |
           set -euo pipefail
           php -r '
           $path = "harness/tools/agent-loop/composer.json";
           $data = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
-          array_unshift($data["repositories"], [
-              "type" => "path",
-              "url" => "../../../candidate/agent-recall-compiler",
-              "options" => [
-                  "symlink" => false,
-                  "versions" => ["voku/agent-recall-compiler" => "0.10.99"],
+          $data["repositories"] = [
+              [
+                  "type" => "path",
+                  "url" => "../../../toolchain/agent-loop",
+                  "options" => [
+                      "symlink" => false,
+                      "versions" => ["voku/agent-loop" => "dev-main"],
+                  ],
               ],
-          ]);
+              [
+                  "type" => "path",
+                  "url" => "../../../candidate/agent-recall-compiler",
+                  "options" => [
+                      "symlink" => false,
+                      "versions" => ["voku/agent-recall-compiler" => "0.10.99"],
+                  ],
+              ],
+          ];
           $data["require-dev"]["voku/agent-recall-compiler"] = "0.10.99";
           file_put_contents($path, json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . PHP_EOL);
           '
@@ -199,6 +217,7 @@ jobs:
           composer show --working-dir=harness/tools/agent-loop --format=json > "${out}/tool-packages.json" 2>/dev/null || true
           sha256sum skills/skills/operational-prompting/operating-prompts.json > "${out}/operating-prompts.sha256" 2>/dev/null || true
           git -C target rev-parse HEAD > "${out}/target-commit.txt"
+          git -C toolchain/agent-loop rev-parse HEAD > "${out}/agent-loop-commit.txt"
           git -C candidate/agent-recall-compiler rev-parse HEAD > "${out}/recall-candidate-commit.txt"
           git -C skills rev-parse HEAD > "${out}/skills-commit.txt"
 

--- a/tools/agent-loop/README.md
+++ b/tools/agent-loop/README.md
@@ -1,0 +1,32 @@
+# Repository-local agent-loop dogfood
+
+This directory is a separate Composer project on purpose.
+
+`voku/agent-loop` is development tooling for this repository, not part of the package contract of `voku/simple-php-code-parser`. Keeping it out of the root `composer.json` avoids raising consumer PHP requirements, leaking agent tooling into downstream installs, and creating first-party dependency cycles such as `agent-map -> agent-loop -> agent-recall-compiler -> agent-map`.
+
+## Real-issue replay
+
+The first replay uses historical issue #60, `Update for use with PHP 8.4`.
+
+The workflow freezes three things before context discovery:
+
+- issue title/body and the pre-fix base commit `5156d5d74ca1bce275219f4571efd54ec44be911`;
+- agent-loop commit `9db5683b79996928553e13dcdb976037615d5742` plus the task-mentioned Composer dependency candidate from `agent-recall-compiler`;
+- agent-skills commit `c7e9d8bdda59d957600bca8dc9f787f03286b277` and the `reproduce-before-fix` L2 recipe.
+
+The issue input contains no knowledge of the later fix files. `issue-60-oracle.json` is read only after map search and Recall compilation have finished.
+
+The historical fix in PR #84 changed:
+
+- `composer.json`;
+- `src/voku/SimplePhpParser/Parsers/PhpCodeParser.php`.
+
+Those files intentionally belong to two different evidence channels. `agent-map` indexes PHP source and is evaluated on whether its pre-fix search result included `PhpCodeParser.php`. Recall owns bounded repository metadata and is required to expose the exact `react/filesystem ^0.2@dev` constraint because the issue names that direct dependency. Recall must not invent Composer scripts when the historical project does not define them.
+
+A map miss is recorded as a finding rather than converted into a fake correctness threshold. Deterministic provenance and Recall contract failures do fail the replay.
+
+## Evidence
+
+GitHub Actions archives the generated tool `composer.lock`, map search output, Recall bundle/facts/system prompt, and post-context evaluation. The lock is part of run evidence because the candidate tool stack is not yet a released coordinated set.
+
+Once the replay is stable, the resolved lock can become the pinned baseline for later comparisons.

--- a/tools/agent-loop/composer.json
+++ b/tools/agent-loop/composer.json
@@ -5,10 +5,10 @@
   "license": "Apache-2.0",
   "require-dev": {
     "voku/agent-kanban": "0.2.1",
-    "voku/agent-learning": "0.8.12",
+    "voku/agent-learning": "0.10.0",
     "voku/agent-loop": "dev-main",
     "voku/agent-map": "0.7.0",
-    "voku/agent-session": "0.3.0",
+    "voku/agent-session": "0.5.0",
     "voku/simple-cache": "6.1.0",
     "voku/simple-php-code-parser": "0.22.2",
     "voku/stop-words": "2.0.1"

--- a/tools/agent-loop/composer.json
+++ b/tools/agent-loop/composer.json
@@ -3,16 +3,10 @@
   "description": "Repository-local agent-loop tooling for real-issue dogfood replays.",
   "type": "project",
   "license": "Apache-2.0",
-  "repositories": [
-    {
-      "type": "vcs",
-      "url": "https://github.com/voku/agent-loop.git"
-    }
-  ],
   "require-dev": {
     "voku/agent-kanban": "0.2.1",
     "voku/agent-learning": "0.8.12",
-    "voku/agent-loop": "dev-main#9db5683b79996928553e13dcdb976037615d5742",
+    "voku/agent-loop": "dev-main",
     "voku/agent-map": "0.7.0",
     "voku/agent-session": "0.3.0",
     "voku/simple-cache": "6.1.0",

--- a/tools/agent-loop/composer.json
+++ b/tools/agent-loop/composer.json
@@ -1,0 +1,26 @@
+{
+  "name": "voku/simple-php-code-parser-agent-loop-tools",
+  "description": "Repository-local agent-loop tooling for real-issue dogfood replays.",
+  "type": "project",
+  "license": "Apache-2.0",
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "https://github.com/voku/agent-loop.git"
+    },
+    {
+      "type": "vcs",
+      "url": "https://github.com/voku/agent-recall-compiler.git"
+    }
+  ],
+  "require-dev": {
+    "voku/agent-loop": "dev-main#9db5683b79996928553e13dcdb976037615d5742",
+    "voku/agent-recall-compiler": "dev-fix/task-mentioned-composer-dependencies#5a2710970e68e41c96a7c5d015f573fd4ec1d289 as 0.10.99"
+  },
+  "minimum-stability": "dev",
+  "prefer-stable": true,
+  "config": {
+    "allow-plugins": false,
+    "sort-packages": true
+  }
+}

--- a/tools/agent-loop/composer.json
+++ b/tools/agent-loop/composer.json
@@ -7,15 +7,17 @@
     {
       "type": "vcs",
       "url": "https://github.com/voku/agent-loop.git"
-    },
-    {
-      "type": "vcs",
-      "url": "https://github.com/voku/agent-recall-compiler.git"
     }
   ],
   "require-dev": {
+    "voku/agent-kanban": "0.2.1",
+    "voku/agent-learning": "0.8.12",
     "voku/agent-loop": "dev-main#9db5683b79996928553e13dcdb976037615d5742",
-    "voku/agent-recall-compiler": "dev-fix/task-mentioned-composer-dependencies#5a2710970e68e41c96a7c5d015f573fd4ec1d289 as 0.10.99"
+    "voku/agent-map": "0.7.0",
+    "voku/agent-session": "0.3.0",
+    "voku/simple-cache": "6.1.0",
+    "voku/simple-php-code-parser": "0.22.2",
+    "voku/stop-words": "2.0.1"
   },
   "minimum-stability": "dev",
   "prefer-stable": true,

--- a/tools/agent-loop/dogfood/issue-60-oracle.json
+++ b/tools/agent-loop/dogfood/issue-60-oracle.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": "1.0",
+  "kind": "post_context_evaluation_oracle",
+  "issue": 60,
+  "fix_pull_request": 84,
+  "fix_base_commit": "5156d5d74ca1bce275219f4571efd54ec44be911",
+  "fix_merge_commit": "15663692ddb17b32eafa02e8d4cbfa8c045e9028",
+  "changed_files": [
+    "composer.json",
+    "src/voku/SimplePhpParser/Parsers/PhpCodeParser.php"
+  ],
+  "expected_channels": {
+    "agent_map": [
+      "src/voku/SimplePhpParser/Parsers/PhpCodeParser.php"
+    ],
+    "project_metadata": [
+      "composer.json"
+    ]
+  },
+  "notes": "This file is consumed only after pre-fix map and Recall outputs exist. It must never be passed into map search, Recall compilation, or L2 construction. A map miss is recorded as a finding rather than converted into a fake passing threshold."
+}

--- a/tools/agent-loop/dogfood/issue-60.json
+++ b/tools/agent-loop/dogfood/issue-60.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "1.0",
+  "kind": "real_issue_replay_input",
+  "repository": "voku/Simple-PHP-Code-Parser",
+  "issue": {
+    "number": 60,
+    "url": "https://github.com/voku/Simple-PHP-Code-Parser/issues/60",
+    "title": "Update for use with PHP 8.4",
+    "body": "Some outdated libraries make it difficult to install.\n\nProblem 1\n- Root composer.json requires voku/simple-php-code-parser * -> satisfiable by voku/simple-php-code-parser[0.1.0, ..., 0.20.1].\n- voku/simple-php-code-parser[0.1.0, ..., 0.13.0] require nikic/php-parser ~4.4 -> found nikic/php-parser[v4.4.0, ..., v4.19.4] but the package is fixed to v5.4.0 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.\n- voku/simple-php-code-parser[0.7.0, ..., 0.12.0] require jetbrains/phpstorm-stubs 2019.3 -> found jetbrains/phpstorm-stubs[v2019.3] but the package is fixed to v2024.3 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.\n- voku/simple-php-code-parser[0.13.1, ..., 0.14.0] require phpstan/phpdoc-parser 0.4.* -> found phpstan/phpdoc-parser[0.4.0, ..., 0.4.14] but it conflicts with your root composer.json require (^2.1).\n- voku/simple-php-code-parser[0.15.0, ..., 0.16.6] require phpstan/phpdoc-parser ~0.4 -> found phpstan/phpdoc-parser[0.4.0, ..., 0.5.7] but it conflicts with your root composer.json require (^2.1).\n- voku/simple-php-code-parser 0.17.0 requires phpstan/phpdoc-parser ~0.5 -> found phpstan/phpdoc-parser[0.5.0, ..., 0.5.7] but it conflicts with your root composer.json require (^2.1).\n- voku/simple-php-code-parser[0.18.0, ..., 0.19.2] require phpdocumentor/type-resolver ~1.5.1 -> found phpdocumentor/type-resolver[1.5.1] but the package is fixed to 1.10.0 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.\n- voku/simple-php-code-parser[0.19.3, ..., 0.19.6] require phpdocumentor/type-resolver ~1.6.1 -> found phpdocumentor/type-resolver[1.6.1, 1.6.2] but the package is fixed to 1.10.0 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.\n- voku/simple-php-code-parser[0.20.0, ..., 0.20.1] require react/filesystem ^0.2@dev -> found react/filesystem[0.2.x-dev] but it does not match your minimum-stability.\n\nUse the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.\nYou can also try re-running composer require with an explicit version constraint, e.g. \"composer require voku/simple-php-code-parser:*\" to figure out if any version is installable, or \"composer require voku/simple-php-code-parser:^2.1\" if you know which you need."
+  },
+  "target_base_commit": "5156d5d74ca1bce275219f4571efd54ec44be911",
+  "toolchain": {
+    "agent_loop_commit": "9db5683b79996928553e13dcdb976037615d5742",
+    "agent_recall_compiler_candidate_commit": "5a2710970e68e41c96a7c5d015f573fd4ec1d289",
+    "agent_skills_commit": "c7e9d8bdda59d957600bca8dc9f787f03286b277",
+    "operating_prompt": "reproduce-before-fix"
+  }
+}

--- a/tools/agent-loop/dogfood/issue-60.json
+++ b/tools/agent-loop/dogfood/issue-60.json
@@ -10,7 +10,7 @@
   },
   "target_base_commit": "5156d5d74ca1bce275219f4571efd54ec44be911",
   "toolchain": {
-    "agent_loop_commit": "9db5683b79996928553e13dcdb976037615d5742",
+    "agent_loop_commit": "206cfdb3199740d85f342699e34a19744c554ef5",
     "agent_recall_compiler_candidate_commit": "5a2710970e68e41c96a7c5d015f573fd4ec1d289",
     "agent_skills_commit": "c7e9d8bdda59d957600bca8dc9f787f03286b277",
     "operating_prompt": "reproduce-before-fix"


### PR DESCRIPTION
This is a historical real-issue acceptance replay, not a new production fix.

## Why

Capability tests prove that commands exist. This replay asks the harder question: given a real issue before the fix is known, does the installed workflow surface context that later proves useful?

Issue #60 is frozen at pre-fix commit `5156d5d74ca1bce275219f4571efd54ec44be911`. The later verified fix in #84 changed only:

- `composer.json`;
- `src/voku/SimplePhpParser/Parsers/PhpCodeParser.php`.

The issue input does not contain that later PHP path.

## Isolation and provenance

`agent-loop` remains outside the library package contract in `tools/agent-loop/composer.json`.

The replay checks out exact Git commits and injects them as Composer path repositories. This is intentional: an earlier attempt showed that `dev-main#<sha>` can still resolve dependency metadata from a moving branch, so a SHA-looking constraint alone was not sufficient evidence that source and `composer.json` described the same tool revision.

Current frozen inputs:

- target: `5156d5d74ca1bce275219f4571efd54ec44be911`;
- agent-loop: `206cfdb3199740d85f342699e34a19744c554ef5`;
- Recall candidate: `5a2710970e68e41c96a7c5d015f573fd4ec1d289` from `voku/agent-recall-compiler#25`;
- agent-skills: `c7e9d8bdda59d957600bca8dc9f787f03286b277`;
- L2 recipe: `reproduce-before-fix`.

The resolved tool `composer.lock` is archived as run evidence.

## No hindsight leakage

`issue-60.json` contains the real issue input and pre-fix SHA. `issue-60-oracle.json` contains the later verified fix region and is read only after map search and Recall compilation have completed.

The map query is the frozen issue title + body. It is not rewritten after seeing the fix.

## Result

The successful replay run proves the following deterministic facts:

- agent-map built a 51-file PHP map and a 483-chunk search index from the historical repository;
- the later production file `src/voku/SimplePhpParser/Parsers/PhpCodeParser.php` was returned **rank 3 of the top 10** from the frozen issue query;
- Recall exposed the exact task-mentioned direct dependency `react/filesystem` from `require` with constraint `^0.2@dev`;
- the historical project had no Composer scripts, and Recall did not invent any;
- the rendered L2 construction contract explicitly requires `Goal / Context / Constraints / Verification / Done When` and retains the rule that repository commands/tools/APIs/architecture must not be invented.

That direct dependency evidence did not exist before this replay. The deterministic gap became a regression-first fix in `voku/agent-recall-compiler#25` rather than another generic prompt rule.

## What is a gate vs an observation

Hard failure:

- frozen SHA/provenance mismatch;
- missing exact Composer evidence;
- invented project commands;
- missing L2 construction/command-honesty contract.

Observation:

- whether the pre-fix map result contains the later verified production file and at which rank.

A map miss would remain a finding. The workflow does not change the query or threshold to manufacture a pass.

## Normal project CI

The dedicated real-issue replay is green.

The repository's normal matrix separately exposed an existing PHP 8.5 compatibility failure in production behavior while PHP 8.1-8.4 remain green. #100 changes no production PHP or parser tests, so that finding is tracked separately as #101 instead of smuggling a product fix into this harness PR.

## Evidence retained by Actions

- isolated tool `composer.lock` and exact package versions;
- agent-map index and search output;
- Recall facts and `system.md`;
- operating-prompt manifest digest;
- target/tool/Recall/skills SHAs;
- post-context evaluation against #84.

This is the first consumer-repository pilot for `voku/agent-loop#66`.