### PR TITLE
fix: preserve PHP 8.5 relative types and avoid null parent lookup

### DIFF
--- a/.github/workflows/agent-loop-issue-101-dogfood.yml
+++ b/.github/workflows/agent-loop-issue-101-dogfood.yml
@@ -138,9 +138,9 @@ jobs:
             --by issue-101-dogfood \
             --file tests/ReflectionTypeFormattingRegressionTest.php \
             --file src/voku/SimplePhpParser/Parsers/PhpCodeParser.php \
-            --goal='Reproduce and minimally fix the two PHP 8.5 regressions without changing established type semantics.' \
-            --non-goal='Do not redesign the parser or change unrelated PHP-version behavior.' \
-            --validation='vendor/bin/phpunit tests/ReflectionTypeFormattingRegressionTest.php' \
+            --goal 'Reproduce and minimally fix the two PHP 8.5 regressions without changing established type semantics.' \
+            --non-goal 'Do not redesign the parser or change unrelated PHP-version behavior.' \
+            --validation 'vendor/bin/phpunit tests/ReflectionTypeFormattingRegressionTest.php' \
             --tag reflection \
             --tag php85 \
             --operating-prompt-manifest "${skills}" \
@@ -162,7 +162,7 @@ jobs:
               if (!$type instanceof ReflectionNamedType) {
                   throw new RuntimeException("Expected named property type: " . $propertyName);
               }
-              $result["property"]["$propertyName"] = [
+              $result["property"][$propertyName] = [
                   "getName" => $type->getName(),
                   "toString" => (string) $type,
               ];

--- a/.github/workflows/agent-loop-issue-101-dogfood.yml
+++ b/.github/workflows/agent-loop-issue-101-dogfood.yml
@@ -1,0 +1,228 @@
+name: Agent Loop Issue 101 Dogfood
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - dogfood/issue-101-php85
+    paths:
+      - '.github/workflows/agent-loop-issue-101-dogfood.yml'
+      - 'tools/agent-loop/**'
+
+permissions:
+  contents: read
+
+jobs:
+  pre-fix-context-and-reproduction:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout dogfood harness
+        uses: actions/checkout@v4
+        with:
+          path: harness
+          persist-credentials: false
+
+      - name: Checkout frozen pre-fix target
+        uses: actions/checkout@v4
+        with:
+          repository: voku/Simple-PHP-Code-Parser
+          ref: 53f1b5085ee883560afa9326ee914f6b23acd6ae
+          path: target
+          persist-credentials: false
+
+      - name: Checkout pinned agent-loop
+        uses: actions/checkout@v4
+        with:
+          repository: voku/agent-loop
+          ref: 206cfdb3199740d85f342699e34a19744c554ef5
+          path: toolchain/agent-loop
+          persist-credentials: false
+
+      - name: Checkout Recall candidate
+        uses: actions/checkout@v4
+        with:
+          repository: voku/agent-recall-compiler
+          ref: 5a2710970e68e41c96a7c5d015f573fd4ec1d289
+          path: candidate/agent-recall-compiler
+          persist-credentials: false
+
+      - name: Checkout pinned L2 skill catalog
+        uses: actions/checkout@v4
+        with:
+          repository: voku/agent-skills
+          ref: c7e9d8bdda59d957600bca8dc9f787f03286b277
+          path: skills
+          persist-credentials: false
+
+      - name: Setup PHP 8.5 and Composer
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+          extensions: json, mbstring, pdo_sqlite, sqlite3
+          coverage: none
+          tools: composer:v2
+
+      - name: Validate frozen provenance
+        run: |
+          set -euo pipefail
+          issue='harness/tools/agent-loop/dogfood/issue-101.json'
+          test "$(jq -r '.target_base_commit' "${issue}")" = "$(git -C target rev-parse HEAD)"
+          test "$(jq -r '.toolchain.agent_loop_commit' "${issue}")" = "$(git -C toolchain/agent-loop rev-parse HEAD)"
+          test "$(jq -r '.toolchain.agent_recall_compiler_candidate_commit' "${issue}")" = "$(git -C candidate/agent-recall-compiler rev-parse HEAD)"
+          test "$(jq -r '.toolchain.agent_skills_commit' "${issue}")" = "$(git -C skills rev-parse HEAD)"
+
+      - name: Install exact agent toolchain
+        run: |
+          set -euo pipefail
+          php -r '
+          $path = "harness/tools/agent-loop/composer.json";
+          $data = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+          $data["repositories"] = [
+              [
+                  "type" => "path",
+                  "url" => "../../../toolchain/agent-loop",
+                  "options" => ["symlink" => false, "versions" => ["voku/agent-loop" => "dev-main"]],
+              ],
+              [
+                  "type" => "path",
+                  "url" => "../../../candidate/agent-recall-compiler",
+                  "options" => ["symlink" => false, "versions" => ["voku/agent-recall-compiler" => "0.11.99"]],
+              ],
+          ];
+          $data["require-dev"]["voku/agent-recall-compiler"] = "0.11.99";
+          file_put_contents($path, json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . PHP_EOL);
+          '
+          composer update --working-dir=harness/tools/agent-loop --no-interaction --prefer-dist --no-progress
+          composer update --working-dir=target --no-interaction --prefer-dist --no-progress
+
+      - name: Freeze agent-map context from issue text before any fix
+        run: |
+          set -euo pipefail
+          out='target/.agent-loop/dogfood/issue-101'
+          mkdir -p "${out}" 'target/.agent-loop/map'
+          harness/tools/agent-loop/vendor/bin/agent-map build \
+            --root=target \
+            --paths=src,tests \
+            --out=target/.agent-loop/map/php-symbols.json
+          harness/tools/agent-loop/vendor/bin/agent-map search-index build \
+            --root=target \
+            --index=target/.agent-loop/map/php-symbols.json \
+            --database=target/.agent-loop/map/search.sqlite
+          query="$(jq -r '.issue | .title + "\n\n" + .body' harness/tools/agent-loop/dogfood/issue-101.json)"
+          harness/tools/agent-loop/vendor/bin/agent-map search "${query}" \
+            --root=target \
+            --index=target/.agent-loop/map/php-symbols.json \
+            --database=target/.agent-loop/map/search.sqlite \
+            --limit=15 \
+            --format=json > "${out}/map-search.json"
+
+      - name: Run governed PLAN APPROVE CONTEXT with reproduce-before-fix L2
+        working-directory: target
+        run: |
+          set -euo pipefail
+          loop='../harness/tools/agent-loop/vendor/bin/agent-loop'
+          skills='../skills/skills/operational-prompting/operating-prompts.json'
+          issue='../harness/tools/agent-loop/dogfood/issue-101.json'
+          query="$(jq -r '.issue | .title + "\n\n" + .body' "${issue}")"
+
+          "${loop}" init scaffold
+          mkdir -p .agent-loop/tasks
+          printf '# GH-101\n\n%s\n' "${query}" > .agent-loop/tasks/GH-101.md
+          "${loop}" board card create GH-101 \
+            --title='PHP 8.5 reflection and null-array-key regression' \
+            --lane=READY \
+            --status=Selected
+          "${loop}" workflow plan GH-101 \
+            --by issue-101-dogfood \
+            --file tests/ReflectionTypeFormattingRegressionTest.php \
+            --file src/voku/SimplePhpParser/Parsers/PhpCodeParser.php \
+            --goal='Reproduce and minimally fix the two PHP 8.5 regressions without changing established type semantics.' \
+            --non-goal='Do not redesign the parser or change unrelated PHP-version behavior.' \
+            --validation='vendor/bin/phpunit tests/ReflectionTypeFormattingRegressionTest.php' \
+            --tag reflection \
+            --tag php85 \
+            --operating-prompt-manifest "${skills}" \
+            --operating-prompt '{"id":"reproduce-before-fix","arguments":{}}'
+          "${loop}" workflow approve GH-101 --by issue-101-dogfood
+          "${loop}" workflow context GH-101 > .agent-loop/dogfood/issue-101/workflow-context.txt
+
+      - name: Probe PHP 8.5 reflection representation directly
+        working-directory: target
+        run: |
+          set -euo pipefail
+          out='.agent-loop/dogfood/issue-101/reflection-probe.json'
+          php -r '
+          require "vendor/autoload.php";
+          $class = new ReflectionClass(voku\tests\ReflectionTypeFixture::class);
+          $result = [];
+          foreach (["classType", "selfType"] as $propertyName) {
+              $type = $class->getProperty($propertyName)->getType();
+              if (!$type instanceof ReflectionNamedType) {
+                  throw new RuntimeException("Expected named property type: " . $propertyName);
+              }
+              $result["property"]["$propertyName"] = [
+                  "getName" => $type->getName(),
+                  "toString" => (string) $type,
+              ];
+          }
+          $method = $class->getMethod("method");
+          foreach ($method->getParameters() as $parameter) {
+              if (!in_array($parameter->getName(), ["classType", "selfType"], true)) {
+                  continue;
+              }
+              $type = $parameter->getType();
+              if (!$type instanceof ReflectionNamedType) {
+                  throw new RuntimeException("Expected named parameter type: " . $parameter->getName());
+              }
+              $result["parameter"][$parameter->getName()] = [
+                  "getName" => $type->getName(),
+                  "toString" => (string) $type,
+              ];
+          }
+          file_put_contents($argv[1], json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . PHP_EOL);
+          ' "${out}"
+          cat "${out}"
+
+      - name: Prove the frozen PHP 8.5 regression before mutation
+        working-directory: target
+        run: |
+          set -euo pipefail
+          out='.agent-loop/dogfood/issue-101/focused-test.log'
+          set +e
+          vendor/bin/phpunit tests/ReflectionTypeFormattingRegressionTest.php --colors=never > "${out}" 2>&1
+          status="$?"
+          set -e
+          cat "${out}"
+          test "${status}" -ne 0
+          grep -F 'selfType' "${out}" >/dev/null
+          printf '%s\n' "${status}" > .agent-loop/dogfood/issue-101/focused-test.exit
+
+      - name: Capture L2 and provenance evidence
+        if: always()
+        run: |
+          set -euo pipefail
+          out='target/.agent-loop/dogfood/issue-101'
+          cp harness/tools/agent-loop/composer.lock "${out}/tool-composer.lock" 2>/dev/null || true
+          composer show --working-dir=harness/tools/agent-loop --format=json > "${out}/tool-packages.json" 2>/dev/null || true
+          find target/.agent-loop/recall -type f -path '*/GH-101/system.md' -exec cp '{}' "${out}/system.md" \; -quit 2>/dev/null || true
+          find target/.agent-loop/recall -type f -path '*/GH-101/facts.json' -exec cp '{}' "${out}/facts.json" \; -quit 2>/dev/null || true
+          sha256sum skills/skills/operational-prompting/operating-prompts.json > "${out}/operating-prompts.sha256" 2>/dev/null || true
+          git -C target rev-parse HEAD > "${out}/target-commit.txt"
+          git -C toolchain/agent-loop rev-parse HEAD > "${out}/agent-loop-commit.txt"
+          git -C candidate/agent-recall-compiler rev-parse HEAD > "${out}/recall-candidate-commit.txt"
+          git -C skills rev-parse HEAD > "${out}/skills-commit.txt"
+
+      - name: Upload immutable pre-fix evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: issue-101-pre-fix-${{ github.sha }}
+          if-no-files-found: error
+          include-hidden-files: true
+          path: |
+            target/.agent-loop/dogfood/issue-101
+            target/.agent-loop/map/php-symbols.json
+            target/.agent-loop/contracts/GH-101
+            target/.agent-loop/runs/GH-101

--- a/.github/workflows/agent-loop-issue-101-dogfood.yml
+++ b/.github/workflows/agent-loop-issue-101-dogfood.yml
@@ -8,6 +8,8 @@ on:
     paths:
       - '.github/workflows/agent-loop-issue-101-dogfood.yml'
       - 'tools/agent-loop/**'
+      - 'src/**'
+      - 'tests/**'
 
 permissions:
   contents: read
@@ -226,3 +228,41 @@ jobs:
             target/.agent-loop/map/php-symbols.json
             target/.agent-loop/contracts/GH-101
             target/.agent-loop/runs/GH-101
+
+  candidate-product-gates:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.1', '8.2', '8.3', '8.4', '8.5']
+        parser-version: [v4, v5]
+
+    steps:
+      - name: Checkout candidate
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+          extensions: zip
+          tools: composer:v2
+
+      - name: Install dependencies like project CI
+        run: |
+          set -euo pipefail
+          if [[ "${{ matrix.parser-version }}" == "v4" ]]; then
+            composer update --prefer-dist --no-interaction --with nikic/php-parser:'^4.18' --with phpunit/phpunit:'^9.6'
+          else
+            composer update --prefer-dist --no-interaction
+          fi
+          composer dump-autoload -o
+
+      - name: Run project PHPUnit gate
+        run: php vendor/bin/phpunit -c phpunit.xml
+
+      - name: Run project PHPStan gate
+        if: ${{ matrix.php == '8.3' }}
+        run: php vendor/bin/phpstan analyse

--- a/src/voku/SimplePhpParser/Model/PHPClass.php
+++ b/src/voku/SimplePhpParser/Model/PHPClass.php
@@ -98,6 +98,9 @@ class PHPClass extends BasePHPClass
                 $propertyNameTmp = $this->getConstantFQN($property, $propertyItem->name->name);
 
                 if (isset($this->properties[$propertyNameTmp])) {
+                    if (self::containsRelativeType($property->type)) {
+                        $this->properties[$propertyNameTmp]->type = null;
+                    }
                     $this->properties[$propertyNameTmp] = $this->properties[$propertyNameTmp]->readObjectFromPhpNode($property, $this->name, $propertyItem);
                 } else {
                     $this->properties[$propertyNameTmp] = (new PHPProperty($this->parserContainer))->readObjectFromPhpNode($property, $this->name, $propertyItem);
@@ -113,6 +116,20 @@ class PHPClass extends BasePHPClass
             $methodNameTmp = $method->name->name;
 
             if (isset($this->methods[$methodNameTmp])) {
+                if (self::containsRelativeType($method->returnType)) {
+                    $this->methods[$methodNameTmp]->returnType = null;
+                }
+                foreach ($method->getParams() as $parameter) {
+                    $parameterName = $parameter->var->name ?? null;
+                    if (
+                        \is_string($parameterName)
+                        && isset($this->methods[$methodNameTmp]->parameters[$parameterName])
+                        && self::containsRelativeType($parameter->type)
+                    ) {
+                        $this->methods[$methodNameTmp]->parameters[$parameterName]->type = null;
+                    }
+                }
+
                 $this->methods[$methodNameTmp] = $this->methods[$methodNameTmp]->readObjectFromPhpNode($method, $this->name);
             } else {
                 $this->methods[$methodNameTmp] = (new PHPMethod($this->parserContainer))->readObjectFromPhpNode($method, $this->name);
@@ -549,5 +566,35 @@ class PHPClass extends BasePHPClass
             $existingProperty->defaultValue = $promotedProperty->defaultValue;
             $existingProperty->typeFromDefaultValue = $promotedProperty->typeFromDefaultValue;
         }
+    }
+
+    private static function containsRelativeType(?\PhpParser\Node $type): bool
+    {
+        if ($type === null) {
+            return false;
+        }
+
+        if ($type instanceof \PhpParser\Node\Name) {
+            return \in_array(\strtolower($type->toString()), ['self', 'parent', 'static'], true);
+        }
+
+        foreach ($type->getSubNodeNames() as $subNodeName) {
+            $subNode = $type->{$subNodeName};
+            if ($subNode instanceof \PhpParser\Node && self::containsRelativeType($subNode)) {
+                return true;
+            }
+
+            if (!\is_array($subNode)) {
+                continue;
+            }
+
+            foreach ($subNode as $innerNode) {
+                if ($innerNode instanceof \PhpParser\Node && self::containsRelativeType($innerNode)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 }

--- a/src/voku/SimplePhpParser/Parsers/PhpCodeParser.php
+++ b/src/voku/SimplePhpParser/Parsers/PhpCodeParser.php
@@ -526,6 +526,10 @@ final class PhpCodeParser
                 $method->parameters = self::mergeMissingParameterTypeFields($method->parameters, $interfaceMethod->parameters);
             }
 
+            if ($class->parentClass === null) {
+                continue;
+            }
+
             if (!isset($classes[$class->parentClass])) {
                 continue;
             }

--- a/tests/InheritdocWithoutParentRegressionTest.php
+++ b/tests/InheritdocWithoutParentRegressionTest.php
@@ -27,7 +27,7 @@ final class Standalone
 }
 PHP;
 
-        $previousHandler = \set_error_handler(
+        \set_error_handler(
             static function (int $severity, string $message, string $file, int $line): bool {
                 if (
                     $severity === \E_DEPRECATED
@@ -50,6 +50,5 @@ PHP;
             'NotLoadable\\InheritdocWithoutParent\\Standalone',
             $container->getClasses()
         );
-        static::assertSame(null, $previousHandler);
     }
 }

--- a/tests/InheritdocWithoutParentRegressionTest.php
+++ b/tests/InheritdocWithoutParentRegressionTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace voku\tests;
+
+use ErrorException;
+use PHPUnit\Framework\TestCase;
+use voku\SimplePhpParser\Parsers\PhpCodeParser;
+
+/**
+ * @internal
+ */
+final class InheritdocWithoutParentRegressionTest extends TestCase
+{
+    public function testInheritdocMethodWithoutParentDoesNotUseNullAsArrayKey(): void
+    {
+        $source = <<<'PHP'
+<?php
+
+namespace NotLoadable\InheritdocWithoutParent;
+
+final class Standalone
+{
+    /** @inheritdoc */
+    public function execute(): void {}
+}
+PHP;
+
+        $previousHandler = \set_error_handler(
+            static function (int $severity, string $message, string $file, int $line): bool {
+                if (
+                    $severity === \E_DEPRECATED
+                    && \str_contains($message, 'Using null as an array offset is deprecated')
+                ) {
+                    throw new ErrorException($message, 0, $severity, $file, $line);
+                }
+
+                return false;
+            }
+        );
+
+        try {
+            $container = PhpCodeParser::getFromString($source);
+        } finally {
+            \restore_error_handler();
+        }
+
+        static::assertArrayHasKey(
+            'NotLoadable\\InheritdocWithoutParent\\Standalone',
+            $container->getClasses()
+        );
+        static::assertSame(null, $previousHandler);
+    }
+}

--- a/tests/ReflectionTypeFormattingRegressionTest.php
+++ b/tests/ReflectionTypeFormattingRegressionTest.php
@@ -10,10 +10,12 @@ use voku\SimplePhpParser\Parsers\Helper\ParserContainer;
 use voku\SimplePhpParser\Parsers\PhpCodeParser;
 
 /**
- * Locks down how `PHPProperty::$type` / `PHPParameter::$type` are rendered.
+ * Locks down how native PHP types are rendered by reflection-only and AST-backed parsing.
  *
- * Both the AST path and the reflection path have to produce the very same
- * strings, and neither of them may autoload a type just to format it.
+ * PHP 8.5 resolves lexical `self` to the declaring class in ReflectionNamedType. Pure
+ * reflection therefore cannot recover whether the source said `self` or the explicit
+ * current class name. AST-backed parsing still owns the source syntax and must preserve
+ * the established source-level `self` representation.
  *
  * @internal
  */
@@ -65,12 +67,22 @@ final class ReflectionTypeFormattingRegressionTest extends TestCase
             new \ReflectionClass(ReflectionTypeFixture::class)
         );
 
-        foreach (self::EXPECTED_PROPERTY_TYPES as $propertyName => $expectedType) {
+        $expectedPropertyTypes = self::EXPECTED_PROPERTY_TYPES;
+        $expectedParameterTypes = self::EXPECTED_PARAMETER_TYPES;
+        if (\PHP_VERSION_ID >= 80500) {
+            // PHP 8.5 resolves both `self` and an explicit current-class declaration to the
+            // same ReflectionNamedType name. Pretending we can recover the source token here
+            // would also turn the explicit classType into `self`.
+            $expectedPropertyTypes['selfType'] = '\\voku\\tests\\ReflectionTypeFixture';
+            $expectedParameterTypes['selfType'] = '\\voku\\tests\\ReflectionTypeFixture';
+        }
+
+        foreach ($expectedPropertyTypes as $propertyName => $expectedType) {
             static::assertArrayHasKey($propertyName, $class->properties);
             static::assertSame($expectedType, $class->properties[$propertyName]->type, 'property: ' . $propertyName);
         }
 
-        foreach (self::EXPECTED_PARAMETER_TYPES as $parameterName => $expectedType) {
+        foreach ($expectedParameterTypes as $parameterName => $expectedType) {
             static::assertArrayHasKey($parameterName, $class->methods['method']->parameters);
             static::assertSame(
                 $expectedType,
@@ -78,9 +90,14 @@ final class ReflectionTypeFormattingRegressionTest extends TestCase
                 'parameter: ' . $parameterName
             );
         }
+
+        $expectedReturnType = \PHP_VERSION_ID >= 80500
+            ? ReflectionTypeFixture::class
+            : 'self';
+        static::assertSame($expectedReturnType, $class->methods['method']->returnType);
     }
 
-    public function testTypesFromFullParseMatchPureReflection(): void
+    public function testFullParsePreservesSourceLevelRelativeTypes(): void
     {
         $class = PhpCodeParser::getPhpFiles(__DIR__ . '/ReflectionTypeFixture.php')
             ->getClasses()[ReflectionTypeFixture::class];
@@ -96,13 +113,31 @@ final class ReflectionTypeFormattingRegressionTest extends TestCase
                 'parameter: ' . $parameterName
             );
         }
+
+        static::assertSame('self', $class->methods['method']->returnType);
+    }
+
+    public function testPhp85ReflectionCannotDistinguishSelfFromExplicitCurrentClass(): void
+    {
+        if (\PHP_VERSION_ID < 80500) {
+            static::markTestSkipped('PHP 8.5 changed relative ReflectionNamedType resolution.');
+        }
+
+        $reflection = new \ReflectionClass(ReflectionTypeFixture::class);
+        $classType = $reflection->getProperty('classType')->getType();
+        $selfType = $reflection->getProperty('selfType')->getType();
+
+        static::assertInstanceOf(\ReflectionNamedType::class, $classType);
+        static::assertInstanceOf(\ReflectionNamedType::class, $selfType);
+        static::assertSame($classType->getName(), $selfType->getName());
+        static::assertSame((string) $classType, (string) $selfType);
     }
 
     /**
      * The very same declarations, but in a namespace that cannot be autoloaded,
-     * so only the AST path runs. It has to agree with the reflection path.
+     * so only the AST path runs. Source-level relative types must stay lexical.
      */
-    public function testAstOnlyPathRendersTheSameTypes(): void
+    public function testAstOnlyPathRendersSourceLevelTypes(): void
     {
         $source = <<<'PHP'
 <?php
@@ -141,7 +176,7 @@ class Subject
         int|string $unionType,
         callable $callableType,
         $untyped = null
-    ) {}
+    ): self {}
 }
 PHP;
 
@@ -188,6 +223,8 @@ PHP;
                 'parameter: ' . $parameterName
             );
         }
+
+        static::assertSame('self', $class->methods['method']->returnType);
     }
 
     /**

--- a/tools/agent-loop/dogfood/issue-101.json
+++ b/tools/agent-loop/dogfood/issue-101.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "1.0",
+  "kind": "real_issue_input",
+  "repository": "voku/Simple-PHP-Code-Parser",
+  "issue": {
+    "number": 101,
+    "url": "https://github.com/voku/Simple-PHP-Code-Parser/issues/101",
+    "title": "PHP 8.5: reflection `self` formatting diverges and null array-key deprecations surface",
+    "body": "The normal CI matrix exposed a current PHP 8.5-only failure while running the isolated agent-loop replay in #100. #100 does not modify production PHP or parser tests, so this is a separate product/runtime compatibility issue rather than part of that dogfood harness. On PHP 8.5.9, both parser-v4 and parser-v5 jobs fail while corresponding PHP 8.1-8.4 jobs pass. ReflectionTypeFormattingRegressionTest expects selfType to be 'self', but pure reflection and the full parse produce '\\voku\\tests\\ReflectionTypeFixture'. PHP 8.5 also reports 'Using null as an array offset is deprecated, use an empty string instead' at src/voku/SimplePhpParser/Parsers/PhpCodeParser.php:529. Treat the observations independently unless evidence proves one root cause. Preserve the intended cross-version public type model, AST/reflection consistency, parser-v4/v5 compatibility, existing PHP 8.1-8.4 behavior, PHPUnit and PHPStan."
+  },
+  "target_base_commit": "53f1b5085ee883560afa9326ee914f6b23acd6ae",
+  "toolchain": {
+    "agent_loop_commit": "206cfdb3199740d85f342699e34a19744c554ef5",
+    "agent_recall_compiler_candidate_commit": "5a2710970e68e41c96a7c5d015f573fd4ec1d289",
+    "agent_skills_commit": "c7e9d8bdda59d957600bca8dc9f787f03286b277",
+    "operating_prompt": "reproduce-before-fix"
+  }
+}


### PR DESCRIPTION
Fixes #101.

This is the second real-issue acceptance run after #100. #100 is now merged into `master`; this branch was tree-preservingly rebased onto merge commit `543226dabdbb0096129b2e90353838a158badc5d`, so `master` is the exact merge base and the PR contains only the #101 work.

## Frozen reproduction before production mutation

Issue #101 is frozen against pre-fix master commit `53f1b5085ee883560afa9326ee914f6b23acd6ae`. The pinned toolchain executes the real governed `agent-loop` PLAN -> APPROVE -> CONTEXT path before production edits.

On PHP 8.5.9 the frozen evidence proves:

- the focused reflection regression is red before mutation;
- Reflection returns the same resolved declaring-class FQCN for lexical `self` and an explicit current-class type, so pure Reflection cannot recover the original lexical spelling;
- the null-array-key deprecation is independent;
- pre-fix map, Recall/L2, Reflection probe and reproduction artifacts are retained immutably.

That rejects the tempting `declaring-class FQCN => self` normalization because it would corrupt explicit current-class declarations.

## Production fix

### Preserve lexical relative types where AST still has evidence

Reflection hydration remains enabled for normal metadata and normal types. During AST-backed class hydration, `PHPClass` clears only a reflected member type whose concrete AST type contains `self`, `parent`, or `static`; the existing property/parameter/return AST readers then repopulate the lexical source type.

Boundary:

- pure Reflection on PHP >= 8.5 exposes the resolved FQCN because lexical spelling is gone;
- AST-backed/full parsing preserves `self` / `parent` / `static` because the source node proves it;
- explicit current-class FQCNs are not rewritten to `self`;
- unrelated Reflection metadata and types remain unchanged.

### Avoid null parent lookup without changing interface inheritdoc

`mergeInheritdocData()` still merges interface method data first. Before parent-method lookup it now continues when `parentClass === null`, so `null` is never used as an array key and interface-only `@inheritdoc` remains valid.

## Regression-first history

The semantic and null-key regression tests precede both production commits. A later test-only correction removed one unrelated assumption that PHPUnit had no pre-existing error handler; the actual regression handler remains scoped only to the PHP 8.5 `null as an array offset` deprecation.

The rebase after #100 was deterministic rather than patch-reconstructed: the squash merge of #100 and the old #100 head have the same tree SHA, so all nine #102 intermediate trees were re-parented unchanged onto the new `master`. An additional tree-identical CI commit exists only to give GitHub a fresh post-stack-removal head.

## Validation

Current head: `157a416bc5255e47e5c40a40258167a830ed433f`.

Normal repository CI run `31653593876` is green on this exact head:

- PHP 8.1 / 8.2 / 8.3 / 8.4 / 8.5;
- nikic/php-parser v4 and v5;
- full PHPUnit on all ten combinations;
- PHPStan on both PHP 8.3 parser lines.

The #60 real-issue replay is also green on this head (`31653623646`).

The enhanced #101 dogfood workflow previously passed its 10/10 candidate matrix plus PHPStan and immutable pre-fix reproduction on final tree `b3017e17369d4d582d785a85e726e14be9450215` (`31653153243`). The current head has that exact same tree.

## Self-discovered harness gap

The original #101 workflow froze and reproduced the pre-fix target but did not validate the candidate. This run exposed that omission. The workflow now mirrors the repository's own product matrix instead of inventing a parallel verification contract, so real-issue dogfood proves both sides:

```text
frozen pre-fix evidence -> RED
candidate               -> project-native gates GREEN
```

## agent-map usefulness against the actual fix

The frozen search used only the issue title/body. Top-15 evidence included:

1. `tests/ReflectionTypeFormattingRegressionTest.php`
2. `tests/ReflectionTypeFixture.php`
5. `src/voku/SimplePhpParser/Parsers/PhpCodeParser.php`
8. `src/voku/SimplePhpParser/Model/PHPProperty.php::readObjectFromPhpNode`

Actual production files changed:

- `src/voku/SimplePhpParser/Parsers/PhpCodeParser.php` — direct hit, rank 5;
- `src/voku/SimplePhpParser/Model/PHPClass.php` — missed by the top 15.

The rank-8 `PHPProperty::readObjectFromPhpNode` hit materially helped expose the local Reflection-vs-AST guard and led to the central orchestration point in `PHPClass`, but the search layer did not surface that caller itself.

The frozen map already contains the exact relation:

```text
PHPClass::readObjectFromPhpNode
  -> calls
PHPProperty::readObjectFromPhpNode
```

So this is a retrieval/composition gap, not an analysis gap. A bounded one-hop structural expansion from high-ranked production method hits would have surfaced the real edit locus without changing the frozen query after hindsight. The miss remains recorded rather than repairing the benchmark.

## Scope

No parser redesign, no global Reflection normalization, no unrelated PHP-version cleanup. The production changes are limited to the two demonstrated PHP 8.5 causes, with the candidate-validation harness improvement directly justified by this run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of inherited and reflected type information, including relative types such as `self`, `parent`, and `static`.
  * Prevented deprecation errors when processing `@inheritdoc` in classes without a parent class.
  * Updated PHP 8.5 compatibility for reflection-based type formatting.

* **Tests**
  * Added regression coverage for standalone `@inheritdoc` parsing and PHP 8.5 reflection behavior.

* **Chores**
  * Added automated validation and evidence collection for PHP 8.1–8.5 and multiple parser versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->