### PR TITLE
ci: align agent-map search database with target root

### DIFF
--- a/.github/workflows/agent-loop-issue-101-dogfood.yml
+++ b/.github/workflows/agent-loop-issue-101-dogfood.yml
@@ -111,12 +111,13 @@ jobs:
           harness/tools/agent-loop/vendor/bin/agent-map search-index build \
             --root=target \
             --index=target/.agent-loop/map/php-symbols.json \
-            --database=target/.agent-loop/map/search.sqlite
+            --database=.agent-loop/map/search.sqlite
+          test -f target/.agent-loop/map/search.sqlite
           query="$(jq -r '.issue | .title + "\n\n" + .body' harness/tools/agent-loop/dogfood/issue-101.json)"
           harness/tools/agent-loop/vendor/bin/agent-map search "${query}" \
             --root=target \
             --index=target/.agent-loop/map/php-symbols.json \
-            --database=target/.agent-loop/map/search.sqlite \
+            --database=.agent-loop/map/search.sqlite \
             --limit=15 \
             --format=json > "${out}/map-search.json"
 

--- a/.github/workflows/agent-loop-real-issue-dogfood.yml
+++ b/.github/workflows/agent-loop-real-issue-dogfood.yml
@@ -120,13 +120,14 @@ jobs:
           harness/tools/agent-loop/vendor/bin/agent-map search-index build \
             --root=target \
             --index=target/.agent-loop/map/php-symbols.json \
-            --database=target/.agent-loop/map/search.sqlite
+            --database=.agent-loop/map/search.sqlite
+          test -f target/.agent-loop/map/search.sqlite
 
           query="$(jq -r '.issue | .title + "\n\n" + .body' harness/tools/agent-loop/dogfood/issue-60.json)"
           harness/tools/agent-loop/vendor/bin/agent-map search "${query}" \
             --root=target \
             --index=target/.agent-loop/map/php-symbols.json \
-            --database=target/.agent-loop/map/search.sqlite \
+            --database=.agent-loop/map/search.sqlite \
             --limit=10 \
             --format=json > "${out}/map-search.json"
 


### PR DESCRIPTION
## Root cause

The real #101 map-composition replay exposed a deterministic harness bug shared by the #60 and #101 consumer workflows.

Both called agent-map with:

```text
--root=target
--database=target/.agent-loop/map/search.sqlite
```

`agent-map search-index` and `search` resolve `--database` relative to `--root`, so the database was actually written/read under `target/target/.agent-loop/map/search.sqlite`.

Raw search still appeared green because it reused the same wrong path. Governed agent-loop/Recall correctly looked under `target/.agent-loop/map/search.sqlite`, so search evidence never reached the workflow.

## Fix

In both permanent dogfood workflows:

- pass `.agent-loop/map/search.sqlite` as the root-relative database path;
- assert immediately after build that `target/.agent-loop/map/search.sqlite` exists;
- use the same root-relative path for raw `agent-map search`.

No production PHP, test semantics, tool versions, frozen issue input, or ranking thresholds change.

## Evidence

The first external #101 replay with the old path failed at the structural-context assertion while raw search itself succeeded, proving the split-brain path behavior.

Controlled replay v2 used this exact root-relative path convention against the same frozen #101 target and exact problem text. Run `31654847152` succeeded and proved that governed Recall received ranked navigation evidence and agent-loop #70 recovered the previously missed `PHPClass::readObjectFromPhpNode` caller from the unchanged rank-8 `PHPProperty::readObjectFromPhpNode` lead.

This PR makes the permanent #60/#101 harnesses stop testing a search database that the governed workflow cannot see.