### PR TITLE
feat: expose reusable AST node inspection helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### Unreleased
+## Unreleased
 
 - add `AstNodeInspector` helpers for exact node source slices, one-based start columns, and shallow value-independent AST shape fingerprints so downstream analyzers can reuse parser mechanics without reimplementing traversal plumbing
 
@@ -114,7 +114,7 @@
 
 ### 0.16.6 (2020-12-26)
 
-- "PhpCodeParser" -> optimize exception handling of "amphp/parallel" for async code analyse per file
+- "PhpCodeParser" -> optimize exception handling of "amphp/parallel" for async code analysis per file
 
 ### 0.16.5 (2020-12-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Unreleased
+
+- add `AstNodeInspector` helpers for exact node source slices, one-based start columns, and shallow value-independent AST shape fingerprints so downstream analyzers can reuse parser mechanics without reimplementing traversal plumbing
+
 ### 0.22.2 (2026-08-05)
 
 - BREAKING (output only): `PHPProperty::$type` / `PHPParameter::$type` read via reflection are now consistently fully qualified, e.g. `Psr\Container\ContainerInterface` is now reported as `\Psr\Container\ContainerInterface`. Previously the leading `\` was only added when `class_exists()` happened to be true, so interfaces, enums-in-unloadable-files and any not-yet-autoloadable class silently lost it, while the AST path always emitted it. Both paths now agree. Consumers that compare these strings verbatim have to expect the leading `\` (built-in types, `self`, `parent`, `static` and intersection types are unchanged)
@@ -60,7 +64,7 @@
 
 ### 0.19.5 (2022-08-30)
 
-- support "::class" from PHP 8
+- support for "::class" from PHP 8
 
 
 ### 0.19.4 (2022-08-30)
@@ -100,19 +104,19 @@
 
 - update dependencies
 
-### 0.18.0  (2021-10-03)
+### 0.18.0 (2021-10-03)
 
 - update dependencies
 
-### 0.17.0  (2021-07-27)
+### 0.17.0 (2021-07-27)
 
 - update dependencies
 
-### 0.16.6  (2020-12-26)
+### 0.16.6 (2020-12-26)
 
 - "PhpCodeParser" -> optimize exception handling of "amphp/parallel" for async code analyse per file
 
-### 0.16.5  (2020-12-26)
+### 0.16.5 (2020-12-26)
 
 - "PhpCodeParser" -> ignore exceptions from auto loaded external classes
 
@@ -213,11 +217,10 @@
 
 - "ParserErrorHandler" -> show more parsing errors in the results
 - "PHPInterface" -> fix PhpReflection usage
-- "PHPDefineConstant" -> fix php warning
 
 ### 0.4.2 (2020-05-23)
 
-- "PhpCodeChecker" -> fix "$skipMixedTypesAsError" usage 
+- "PhpCodeCheckerCommand" -> fix "$skipMixedTypesAsError" usage 
 
 ### 0.4.1 (2020-05-23)
 

--- a/src/voku/SimplePhpParser/Parsers/Helper/AstNodeInspector.php
+++ b/src/voku/SimplePhpParser/Parsers/Helper/AstNodeInspector.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace voku\SimplePhpParser\Parsers\Helper;
+
+use PhpParser\Node;
+
+/**
+ * Source-aware helpers for consumers that inspect the raw php-parser AST.
+ */
+final class AstNodeInspector
+{
+    public function __construct(
+        private readonly string $sourceCode
+    ) {
+    }
+
+    /**
+     * Return the exact source slice covered by a node.
+     */
+    public function sourceText(Node $node): ?string
+    {
+        $start = $node->getStartFilePos();
+        $end = $node->getEndFilePos();
+        if ($start < 0 || $end < $start) {
+            return null;
+        }
+
+        return \substr($this->sourceCode, $start, $end - $start + 1);
+    }
+
+    /**
+     * Return the node's one-based start column.
+     */
+    public function startColumn(Node $node): int
+    {
+        $start = $node->getStartFilePos();
+        if ($start < 0) {
+            return 1;
+        }
+
+        $prefix = \substr($this->sourceCode, 0, $start);
+        $lineStart = \strrpos($prefix, "\n");
+
+        return $lineStart === false ? $start + 1 : $start - $lineStart;
+    }
+
+    /**
+     * Build a shallow structural fingerprint from node kinds only.
+     *
+     * Identifiers and literal values deliberately do not participate, which
+     * makes this useful for comparing repeated code shapes without pretending
+     * to perform semantic equivalence analysis.
+     */
+    public function shapeFingerprint(Node $node, int $maxDepth = 4): string
+    {
+        return self::fingerprint($node, \max(0, $maxDepth), 0);
+    }
+
+    private static function fingerprint(Node $node, int $maxDepth, int $depth): string
+    {
+        $label = $node->getType();
+        if ($depth >= $maxDepth) {
+            return $label;
+        }
+
+        $children = [];
+        foreach ($node->getSubNodeNames() as $name) {
+            $value = $node->{$name};
+            if ($value instanceof Node) {
+                $children[] = self::fingerprint($value, $maxDepth, $depth + 1);
+                continue;
+            }
+
+            if (!\is_array($value)) {
+                continue;
+            }
+
+            foreach ($value as $child) {
+                if ($child instanceof Node) {
+                    $children[] = self::fingerprint($child, $maxDepth, $depth + 1);
+                }
+            }
+        }
+
+        return $children === [] ? $label : $label . '(' . \implode(',', $children) . ')';
+    }
+}

--- a/src/voku/SimplePhpParser/Parsers/Helper/AstNodeInspector.php
+++ b/src/voku/SimplePhpParser/Parsers/Helper/AstNodeInspector.php
@@ -11,15 +11,7 @@ use PhpParser\Node;
  */
 final class AstNodeInspector
 {
-    public function __construct(
-        private readonly string $sourceCode
-    ) {
-    }
-
-    /**
-     * Return the exact source slice covered by a node.
-     */
-    public function sourceText(Node $node): ?string
+    public static function sourceText(Node $node, string $sourceCode): ?string
     {
         $start = $node->getStartFilePos();
         $end = $node->getEndFilePos();
@@ -27,21 +19,17 @@ final class AstNodeInspector
             return null;
         }
 
-        return \substr($this->sourceCode, $start, $end - $start + 1);
+        return \substr($sourceCode, $start, $end - $start + 1);
     }
 
-    /**
-     * Return the node's one-based start column.
-     */
-    public function startColumn(Node $node): int
+    public static function startColumn(Node $node, string $sourceCode): int
     {
         $start = $node->getStartFilePos();
         if ($start < 0) {
             return 1;
         }
 
-        $prefix = \substr($this->sourceCode, 0, $start);
-        $lineStart = \strrpos($prefix, "\n");
+        $lineStart = \strrpos(\substr($sourceCode, 0, $start), "\n");
 
         return $lineStart === false ? $start + 1 : $start - $lineStart;
     }
@@ -49,11 +37,9 @@ final class AstNodeInspector
     /**
      * Build a shallow structural fingerprint from node kinds only.
      *
-     * Identifiers and literal values deliberately do not participate, which
-     * makes this useful for comparing repeated code shapes without pretending
-     * to perform semantic equivalence analysis.
+     * Identifiers and literal values deliberately do not participate.
      */
-    public function shapeFingerprint(Node $node, int $maxDepth = 4): string
+    public static function shapeFingerprint(Node $node, int $maxDepth = 4): string
     {
         return self::fingerprint($node, \max(0, $maxDepth), 0);
     }

--- a/tests/AstNodeInspectorTest.php
+++ b/tests/AstNodeInspectorTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace voku\tests;
+
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Stmt\Expression;
+use PhpParser\NodeFinder;
+use PHPUnit\Framework\TestCase;
+use voku\SimplePhpParser\Parsers\Helper\AstNodeInspector;
+use voku\SimplePhpParser\Parsers\PhpCodeParser;
+
+/**
+ * @internal
+ */
+final class AstNodeInspectorTest extends TestCase
+{
+    public function testReadsExactSourceTextAndOneBasedStartColumn(): void
+    {
+        $source = <<<'PHP'
+<?php
+function demo(): void
+{
+    $value = build_value(123);
+}
+PHP;
+        $ast = PhpCodeParser::getAstFromString($source);
+        $assign = (new NodeFinder())->findFirstInstanceOf($ast, Assign::class);
+
+        static::assertInstanceOf(Assign::class, $assign);
+
+        $inspector = new AstNodeInspector($source);
+        static::assertSame('$value = build_value(123)', $inspector->sourceText($assign));
+        static::assertSame(5, $inspector->startColumn($assign));
+    }
+
+    public function testShapeFingerprintIgnoresNamesAndLiteralValues(): void
+    {
+        $first = <<<'PHP'
+<?php
+$left = build_value(123);
+PHP;
+        $second = <<<'PHP'
+<?php
+$right = other_factory(999);
+PHP;
+
+        $firstStatement = (new NodeFinder())->findFirstInstanceOf(
+            PhpCodeParser::getAstFromString($first),
+            Expression::class
+        );
+        $secondStatement = (new NodeFinder())->findFirstInstanceOf(
+            PhpCodeParser::getAstFromString($second),
+            Expression::class
+        );
+
+        static::assertInstanceOf(Expression::class, $firstStatement);
+        static::assertInstanceOf(Expression::class, $secondStatement);
+
+        static::assertSame(
+            (new AstNodeInspector($first))->shapeFingerprint($firstStatement, 5),
+            (new AstNodeInspector($second))->shapeFingerprint($secondStatement, 5)
+        );
+    }
+
+    public function testShapeFingerprintStillDistinguishesDifferentSyntax(): void
+    {
+        $scalar = <<<'PHP'
+<?php
+$value = build_value(123);
+PHP;
+        $array = <<<'PHP'
+<?php
+$value = build_value([123]);
+PHP;
+
+        $scalarStatement = (new NodeFinder())->findFirstInstanceOf(
+            PhpCodeParser::getAstFromString($scalar),
+            Expression::class
+        );
+        $arrayStatement = (new NodeFinder())->findFirstInstanceOf(
+            PhpCodeParser::getAstFromString($array),
+            Expression::class
+        );
+
+        static::assertInstanceOf(Expression::class, $scalarStatement);
+        static::assertInstanceOf(Expression::class, $arrayStatement);
+
+        static::assertNotSame(
+            (new AstNodeInspector($scalar))->shapeFingerprint($scalarStatement, 5),
+            (new AstNodeInspector($array))->shapeFingerprint($arrayStatement, 5)
+        );
+    }
+}

--- a/tests/AstNodeInspectorTest.php
+++ b/tests/AstNodeInspectorTest.php
@@ -11,12 +11,10 @@ use PHPUnit\Framework\TestCase;
 use voku\SimplePhpParser\Parsers\Helper\AstNodeInspector;
 use voku\SimplePhpParser\Parsers\PhpCodeParser;
 
-/**
- * @internal
- */
+/** @internal */
 final class AstNodeInspectorTest extends TestCase
 {
-    public function testReadsExactSourceTextAndOneBasedStartColumn(): void
+    public function testReadsSourceTextAndStartColumn(): void
     {
         $source = <<<'PHP'
 <?php
@@ -25,71 +23,42 @@ function demo(): void
     $value = build_value(123);
 }
 PHP;
-        $ast = PhpCodeParser::getAstFromString($source);
-        $assign = (new NodeFinder())->findFirstInstanceOf($ast, Assign::class);
+        $assign = (new NodeFinder())->findFirstInstanceOf(
+            PhpCodeParser::getAstFromString($source),
+            Assign::class
+        );
 
         static::assertInstanceOf(Assign::class, $assign);
-
-        $inspector = new AstNodeInspector($source);
-        static::assertSame('$value = build_value(123)', $inspector->sourceText($assign));
-        static::assertSame(5, $inspector->startColumn($assign));
+        static::assertSame('$value = build_value(123)', AstNodeInspector::sourceText($assign, $source));
+        static::assertSame(5, AstNodeInspector::startColumn($assign, $source));
     }
 
-    public function testShapeFingerprintIgnoresNamesAndLiteralValues(): void
+    public function testShapeFingerprintIgnoresValuesButKeepsSyntax(): void
     {
         $first = <<<'PHP'
 <?php
 $left = build_value(123);
 PHP;
-        $second = <<<'PHP'
+        $sameShape = <<<'PHP'
 <?php
 $right = other_factory(999);
 PHP;
-
-        $firstStatement = (new NodeFinder())->findFirstInstanceOf(
-            PhpCodeParser::getAstFromString($first),
-            Expression::class
-        );
-        $secondStatement = (new NodeFinder())->findFirstInstanceOf(
-            PhpCodeParser::getAstFromString($second),
-            Expression::class
-        );
-
-        static::assertInstanceOf(Expression::class, $firstStatement);
-        static::assertInstanceOf(Expression::class, $secondStatement);
-
-        static::assertSame(
-            (new AstNodeInspector($first))->shapeFingerprint($firstStatement, 5),
-            (new AstNodeInspector($second))->shapeFingerprint($secondStatement, 5)
-        );
-    }
-
-    public function testShapeFingerprintStillDistinguishesDifferentSyntax(): void
-    {
-        $scalar = <<<'PHP'
+        $differentShape = <<<'PHP'
 <?php
-$value = build_value(123);
-PHP;
-        $array = <<<'PHP'
-<?php
-$value = build_value([123]);
+$right = other_factory([999]);
 PHP;
 
-        $scalarStatement = (new NodeFinder())->findFirstInstanceOf(
-            PhpCodeParser::getAstFromString($scalar),
-            Expression::class
-        );
-        $arrayStatement = (new NodeFinder())->findFirstInstanceOf(
-            PhpCodeParser::getAstFromString($array),
-            Expression::class
-        );
+        $finder = new NodeFinder();
+        $firstNode = $finder->findFirstInstanceOf(PhpCodeParser::getAstFromString($first), Expression::class);
+        $sameShapeNode = $finder->findFirstInstanceOf(PhpCodeParser::getAstFromString($sameShape), Expression::class);
+        $differentShapeNode = $finder->findFirstInstanceOf(PhpCodeParser::getAstFromString($differentShape), Expression::class);
 
-        static::assertInstanceOf(Expression::class, $scalarStatement);
-        static::assertInstanceOf(Expression::class, $arrayStatement);
+        static::assertInstanceOf(Expression::class, $firstNode);
+        static::assertInstanceOf(Expression::class, $sameShapeNode);
+        static::assertInstanceOf(Expression::class, $differentShapeNode);
 
-        static::assertNotSame(
-            (new AstNodeInspector($scalar))->shapeFingerprint($scalarStatement, 5),
-            (new AstNodeInspector($array))->shapeFingerprint($arrayStatement, 5)
-        );
+        $fingerprint = AstNodeInspector::shapeFingerprint($firstNode, 5);
+        static::assertSame($fingerprint, AstNodeInspector::shapeFingerprint($sameShapeNode, 5));
+        static::assertNotSame($fingerprint, AstNodeInspector::shapeFingerprint($differentShapeNode, 5));
     }
 }


### PR DESCRIPTION
Move generic raw-AST inspection work out of downstream consumers such as `slop-scan`.

Adds one cohesive `AstNodeInspector` for operations that are independent of any slop rule:

- exact source slice for a node;
- one-based start column;
- shallow structural fingerprint based on node kinds only.

This deliberately does **not** wrap `NodeFinder` or add rule semantics. `PhpCodeParser::getAstFromString()` / `getAstFromFile()` remain the parser and traversal entry points; consumers should keep their own domain predicates.

Downstream motivation: `voku/slop-scan` currently duplicates source-column logic and a structural fingerprint walker while adapting upstream duplicate mock-setup detection. The parser package is the better owner for those mechanics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added tools for inspecting parsed PHP syntax, including exact source excerpts, one-based starting columns, and structural fingerprints.
  - Structural fingerprints distinguish syntax while ignoring identifier and literal value changes.

- **Documentation**
  - Added unreleased documentation for the new inspection capabilities.
  - Corrected historical changelog wording and release references.
  - Removed an obsolete changelog entry and normalized heading formatting.

- **Tests**
  - Added coverage for source extraction, column detection, and syntax fingerprinting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->