### PR TITLE
Reject duplicate release-set root constraints

### DIFF
--- a/tests/AgentLoopReleaseSetVerifierTest.php
+++ b/tests/AgentLoopReleaseSetVerifierTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace voku\tests;
+
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/** @internal */
+final class AgentLoopReleaseSetVerifierTest extends TestCase
+{
+    public function testRejectsPackageDeclaredInRequireAndRequireDev(): void
+    {
+        $directory = sys_get_temp_dir() . '/simple-php-parser-release-set-' . bin2hex(random_bytes(4));
+        if (!mkdir($directory, 0o775, true) && !is_dir($directory)) {
+            throw new RuntimeException('Unable to create test directory: ' . $directory);
+        }
+
+        $issuePath = $directory . '/issue.json';
+        $composerPath = $directory . '/composer.json';
+
+        try {
+            file_put_contents($issuePath, json_encode([
+                'toolchain' => [
+                    'agent_loop_release' => '0.16.5',
+                ],
+            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR));
+            file_put_contents($composerPath, json_encode([
+                'require' => [
+                    'voku/agent-loop' => '0.16.5',
+                ],
+                'require-dev' => [
+                    'voku/agent-loop' => '0.16.4',
+                ],
+            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR));
+
+            [$exitCode, $stdout, $stderr] = $this->execute([
+                PHP_BINARY,
+                dirname(__DIR__) . '/tools/agent-loop/verify-release-set.php',
+                $issuePath,
+                $composerPath,
+            ]);
+
+            self::assertSame(1, $exitCode, $stdout . $stderr);
+            self::assertSame('', $stdout);
+            self::assertStringContainsString(
+                'must not declare the same package in both require and require-dev: voku/agent-loop',
+                $stderr,
+            );
+        } finally {
+            @unlink($issuePath);
+            @unlink($composerPath);
+            @rmdir($directory);
+        }
+    }
+
+    /**
+     * @param list<string> $command
+     *
+     * @return array{0: int, 1: string, 2: string}
+     */
+    private function execute(array $command): array
+    {
+        $pipes = [];
+        $process = proc_open(
+            $command,
+            [
+                0 => ['pipe', 'r'],
+                1 => ['pipe', 'w'],
+                2 => ['pipe', 'w'],
+            ],
+            $pipes,
+        );
+        if (!is_resource($process)) {
+            throw new RuntimeException('Unable to start verifier process.');
+        }
+
+        fclose($pipes[0]);
+        $stdout = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exitCode = proc_close($process);
+
+        return [
+            $exitCode,
+            is_string($stdout) ? $stdout : '',
+            is_string($stderr) ? $stderr : '',
+        ];
+    }
+}

--- a/tests/AgentLoopReleaseSetVerifierTest.php
+++ b/tests/AgentLoopReleaseSetVerifierTest.php
@@ -21,19 +21,19 @@ final class AgentLoopReleaseSetVerifierTest extends TestCase
         $composerPath = $directory . '/composer.json';
 
         try {
-            file_put_contents($issuePath, json_encode([
+            self::writeJson($issuePath, [
                 'toolchain' => [
                     'agent_loop_release' => '0.16.5',
                 ],
-            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR));
-            file_put_contents($composerPath, json_encode([
+            ]);
+            self::writeJson($composerPath, [
                 'require' => [
                     'voku/agent-loop' => '0.16.5',
                 ],
                 'require-dev' => [
                     'voku/agent-loop' => '0.16.4',
                 ],
-            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR));
+            ]);
 
             [$exitCode, $stdout, $stderr] = $this->execute([
                 PHP_BINARY,
@@ -49,9 +49,25 @@ final class AgentLoopReleaseSetVerifierTest extends TestCase
                 $stderr,
             );
         } finally {
-            @unlink($issuePath);
-            @unlink($composerPath);
-            @rmdir($directory);
+            foreach ([$issuePath, $composerPath] as $path) {
+                if (is_file($path) && !unlink($path)) {
+                    throw new RuntimeException('Unable to remove test file: ' . $path);
+                }
+            }
+            if (is_dir($directory) && !rmdir($directory)) {
+                throw new RuntimeException('Unable to remove test directory: ' . $directory);
+            }
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private static function writeJson(string $path, array $data): void
+    {
+        $json = json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+        if (file_put_contents($path, $json . "\n") === false) {
+            throw new RuntimeException('Unable to write test file: ' . $path);
         }
     }
 

--- a/tools/agent-loop/verify-release-set.php
+++ b/tools/agent-loop/verify-release-set.php
@@ -29,6 +29,17 @@ try {
     $toolchain = requireArray($issue, 'toolchain', $argv[1]);
     $require = stringRequirements($composer['require'] ?? [], 'require', $argv[2]);
     $requireDev = stringRequirements($composer['require-dev'] ?? [], 'require-dev', $argv[2]);
+
+    $duplicatePackages = array_keys(array_intersect_key($require, $requireDev));
+    if ($duplicatePackages !== []) {
+        sort($duplicatePackages, SORT_STRING);
+        throw new \RuntimeException(sprintf(
+            '%s must not declare the same package in both require and require-dev: %s.',
+            $argv[2],
+            implode(', ', $duplicatePackages),
+        ));
+    }
+
     $rootRequirements = $require + $requireDev;
 
     $expectedAgentLoop = requireString($toolchain, 'agent_loop_release', $argv[1]);


### PR DESCRIPTION
## What changed

- reject packages declared in both root `require` and `require-dev` before combining the sections
- add a focused regression test that runs the real standalone verifier with conflicting `voku/agent-loop` constraints

## Why

CodeRabbit correctly found after #116 merged that PHP array union (`$require + $requireDev`) can hide a conflicting duplicate declaration from the right-hand section. That weakens the single-root-authority guarantee.

This follow-up fails deterministically on any duplicate package across the two root sections, before release-set ownership checks continue.